### PR TITLE
Video location and playback handling

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -177,6 +177,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
             InjectSCURKFix();
             break;
         }
+
+        // SMK..
+        GetSMKFuncs();
         
         // Seed the libc RNG -- we'll need this later
         srand((unsigned int)time(NULL));
@@ -318,6 +321,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
         PostThreadMessage(dwMusicThreadID, WM_QUIT, NULL, NULL);
 
         // Send a closing message and close the log file
+        ReleaseSMKFuncs();
         ConsoleLog(LOG_INFO, "CORE: Closing down at %lld. Goodnight!\n", time(NULL));
         fflush(fdLog);
         fclose(fdLog);

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -88,19 +88,6 @@ static const char *AdjustSource(char *buf, const char *path) {
 	return buf;
 }
 
-extern "C" DWORD __stdcall Hook_GetFullPathNameA(LPCSTR lpFileName, DWORD nBufferLength, LPSTR lpBuffer, LPSTR *lpFilePart) {
-	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-		ConsoleLog(LOG_DEBUG, "File:  0x%08X -> GetFullPathNameA(%s, 0x%08x, 0x%08x, 0x%08x)\n", _ReturnAddress(), lpFileName, nBufferLength, lpBuffer, lpFilePart);
-	return GetFullPathNameA(lpFileName, nBufferLength, lpBuffer, lpFilePart);
-}
-
-extern "C" DWORD __stdcall Hook_GetLogicalDrives(void) {
-	DWORD res = GetLogicalDrives();
-	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-		ConsoleLog(LOG_DEBUG, "File:  0x%08X -> GetLogicalDrives(%x%08x)\n", _ReturnAddress(), res);
-	return res;
-}
-
 extern "C" HANDLE __stdcall Hook_CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
 	LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {
 	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
@@ -486,17 +473,11 @@ void InstallMiscHooks(void) {
 
 	AdjustDefDataPathDrive();
 
-	// Install GetLogicalDrives hook
-	*(DWORD*)(0x4EFA60) = (DWORD)Hook_GetLogicalDrives;
-
 	// Install CreateFileA hook
 	*(DWORD*)(0x4EFADC) = (DWORD)Hook_CreateFileA;
 
 	// Install FindFirstFileA hook
 	*(DWORD*)(0x4EFB8C) = (DWORD)Hook_FindFirstFileA;
-
-	// Install GetFullPathNameA hook
-	*(DWORD*)(0x4EFABC) = (DWORD)Hook_GetFullPathNameA;
 
 	// Install LoadStringA hook
 	*(DWORD*)(0x4EFBE8) = (DWORD)Hook_LoadStringA;

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -58,6 +58,8 @@ static void AdjustDefDataPathDrive() {
 	def_data_path[0] = temp[0];
 }
 
+// Reference and inspiration for this comes from the separate
+// 'simcity-noinstall' project.
 static const char *AdjustSource(char *buf, const char *path) {
 	int plen = strlen(path);
 	int flen = strlen(def_data_path);

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -50,7 +50,9 @@ char szCurrentMonthDay[24] = { 0 };
 const char* szMonthNames[12] = { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
 
 static void AdjustDefDataPathDrive() {
-	const char *temp = GetSetGoodiesPath();
+	// Let's get the drive letter from
+	// the movies path.
+	const char *temp = GetSetMoviesPath();
 	if (!temp)
 		return;
 	def_data_path[0] = temp[0];
@@ -64,7 +66,7 @@ static const char *AdjustSource(char *buf, const char *path) {
 	}
 
 	char temp[MAX_PATH+1];
-	const char *ptemp = GetSetGoodiesPath();
+	const char *ptemp = GetSetMoviesPath();
 	if (!ptemp) {
 		return path;
 	}
@@ -75,6 +77,9 @@ static const char *AdjustSource(char *buf, const char *path) {
 
 	strcpy_s(buf, MAX_PATH, ptemp);
 	strcat_s(buf, MAX_PATH, temp);
+
+	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
+		ConsoleLog(LOG_DEBUG, "File: 0x%08X -> Adjustment - %s -> %s\n", _ReturnAddress(), path, buf);
 
 	return buf;
 }

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -12,10 +12,10 @@
 #include <sc2k_1996.h>
 
 // Turning this on enables every debugging option. You have been warned.
-// #define DEBUGALL
+#define DEBUGALL
 
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
-// #define CONSOLE_ENABLED
+#define CONSOLE_ENABLED
 
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1
@@ -106,7 +106,7 @@ extern BOOL bSettingsFixOrdinances;
 
 // Path functions (from registry area)
 
-const char *GetSetGoodiesPath();
+const char *GetSetMoviesPath();
 
 // Utility functions
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -104,6 +104,10 @@ extern BOOL bSettingsUseNewStrings;
 extern BOOL bSettingsMilitaryBaseRevenue;
 extern BOOL bSettingsFixOrdinances;
 
+// Path functions (from registry area)
+
+const char *GetSetGoodiesPath();
+
 // Utility functions
 
 void CenterDialogBox(HWND hwndDlg);

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <random>
 
+#include <smk.h>
 #include <sc2k_1996.h>
 
 // Turning this on enables every debugging option. You have been warned.
@@ -107,6 +108,11 @@ extern BOOL bSettingsFixOrdinances;
 // Path functions (from registry area)
 
 const char *GetSetMoviesPath();
+
+// SMK funcs
+
+void GetSMKFuncs();
+void ReleaseSMKFuncs();
 
 // Utility functions
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -13,10 +13,10 @@
 #include <sc2k_1996.h>
 
 // Turning this on enables every debugging option. You have been warned.
-#define DEBUGALL
+// #define DEBUGALL
 
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
-#define CONSOLE_ENABLED
+// #define CONSOLE_ENABLED
 
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1

--- a/include/smk.h
+++ b/include/smk.h
@@ -1,0 +1,8 @@
+#ifndef __SMK_H__
+#define __SMK_H__
+
+typedef DWORD(__cdecl *SMKOpenPtr) (LPCSTR lpFileName, DWORD a1, DWORD a2);
+
+extern SMKOpenPtr SMKOpenProc;
+
+#endif

--- a/modules/registry_install.cpp
+++ b/modules/registry_install.cpp
@@ -13,9 +13,10 @@
 
 char szSC2KPath[MAX_PATH];
 char szSC2KGoodiesPath[MAX_PATH];
+char szSC2KMoviesPath[MAX_PATH];
 
-const char *GetSetGoodiesPath() {
-	return szSC2KGoodiesPath;
+const char *GetSetMoviesPath() {
+	return szSC2KMoviesPath;
 }
 
 BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {
@@ -71,11 +72,11 @@ BOOL DoRegistryCheckAndInstall(void) {
 
 		// Generate paths
 		char szSC2KExePath[MAX_PATH] = { 0 };
-		char szSC2KPaths[9][MAX_PATH];
+		char szSC2KPaths[10][MAX_PATH];
 		GetModuleFileNameEx(GetCurrentProcess(), NULL, szSC2KExePath, MAX_PATH);
 		PathRemoveFileSpecA(szSC2KExePath);
 		
-		for (int i = 0; i < 9; i++)
+		for (int i = 0; i < 10; i++)
 			strcpy_s(szSC2KPaths[i], MAX_PATH, szSC2KExePath);
 
 		strcat_s(szSC2KPaths[0], MAX_PATH, "\\CITIES");
@@ -87,8 +88,9 @@ BOOL DoRegistryCheckAndInstall(void) {
 		strcat_s(szSC2KPaths[6], MAX_PATH, "\\CITIES");
 		strcat_s(szSC2KPaths[7], MAX_PATH, "\\SCENARIO");
 		strcat_s(szSC2KPaths[8], MAX_PATH, "\\SCURKART");
+		strcat_s(szSC2KPaths[9], MAX_PATH, "\\Movies");
 
-		strcpy_s(szSC2KGoodiesPath, MAX_PATH, szSC2KPaths[2]);
+		strcpy_s(szSC2KMoviesPath, MAX_PATH, szSC2KPaths[9]);
 
 		// Write paths
 		HKEY hkeySC2KPaths;
@@ -102,6 +104,7 @@ BOOL DoRegistryCheckAndInstall(void) {
 		RegSetValueEx(hkeySC2KPaths, "SaveGame", NULL, REG_SZ, (BYTE*)szSC2KPaths[6], strlen(szSC2KPaths[6]) + 1);
 		RegSetValueEx(hkeySC2KPaths, "Scenarios", NULL, REG_SZ, (BYTE*)szSC2KPaths[7], strlen(szSC2KPaths[7]) + 1);
 		RegSetValueEx(hkeySC2KPaths, "TileSets", NULL, REG_SZ, (BYTE*)szSC2KPaths[8], strlen(szSC2KPaths[8]) + 1);
+		RegSetValueEx(hkeySC2KPaths, "Movies", NULL, REG_SZ, (BYTE*)szSC2KPaths[9], strlen(szSC2KPaths[9]) + 1);
 
 		// Write version info
 		HKEY hkeySC2KVersion;
@@ -139,8 +142,8 @@ BOOL DoRegistryCheckAndInstall(void) {
 			return FALSE;
 		}
 
-		DWORD dwSC2KGoodiesPathSize = MAX_PATH + 1;
-		LSTATUS retval = RegGetValue(hkeySC2KPaths, NULL, "Goodies", RRF_RT_REG_SZ, NULL, szSC2KGoodiesPath, &dwSC2KGoodiesPathSize);
+		DWORD dwSC2KMoviesPathSize = MAX_PATH;
+		LSTATUS retval = RegGetValue(hkeySC2KPaths, NULL, "Movies", RRF_RT_REG_SZ, NULL, szSC2KMoviesPath, &dwSC2KMoviesPathSize);
 		switch (retval) {
 		case ERROR_SUCCESS:
 			break;
@@ -150,12 +153,15 @@ BOOL DoRegistryCheckAndInstall(void) {
 			GetModuleFileNameEx(GetCurrentProcess(), NULL, szSC2KExePath, MAX_PATH);
 			PathRemoveFileSpecA(szSC2KExePath);
 
-			strcpy_s(szSC2KGoodiesPath, szSC2KExePath);
-			strcat_s(szSC2KGoodiesPath, MAX_PATH, "\\GOODIES");
+			strcpy_s(szSC2KMoviesPath, szSC2KExePath);
+			strcat_s(szSC2KMoviesPath, MAX_PATH, "\\MOVIES");
+
+			RegSetValueEx(hkeySC2KPaths, "Movies", NULL, REG_SZ, (BYTE*)szSC2KMoviesPath, strlen(szSC2KMoviesPath) + 1);
 
 			char* buf;
 			FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, retval, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
-			ConsoleLog(LOG_WARNING, "CORE: Error %s loading 'Goodies' path; resetting to default.\n", buf);
+			ConsoleLog(LOG_WARNING, "CORE: Error loading 'Goodies' path; resetting to default. Reg: %s", buf); // The lack of the newline is deliberate.
+
 			break;
 		}
 	}

--- a/modules/registry_install.cpp
+++ b/modules/registry_install.cpp
@@ -160,7 +160,7 @@ BOOL DoRegistryCheckAndInstall(void) {
 
 			char* buf;
 			FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, retval, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
-			ConsoleLog(LOG_WARNING, "CORE: Error loading 'Goodies' path; resetting to default. Reg: %s", buf); // The lack of the newline is deliberate.
+			ConsoleLog(LOG_WARNING, "CORE: Error loading 'Movies' path; resetting to default. Reg: %s", buf); // The lack of the newline is deliberate.
 
 			break;
 		}

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
@@ -62,6 +62,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="include\sc2kfix.h" />
+    <ClInclude Include="include\smk.h" />
     <ClInclude Include="include\winmm_exports.h" />
     <ClInclude Include="include\sc2k_1996.h" />
     <ClInclude Include="resource.h" />
@@ -80,6 +81,7 @@
     <ClCompile Include="modules\settings.cpp" />
     <ClCompile Include="modules\status_dialog.cpp" />
     <ClCompile Include="modules\update_notifier.cpp" />
+    <ClCompile Include="smk.cpp" />
     <ClCompile Include="utility.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/sc2kfix.vcxproj.filters
+++ b/sc2kfix.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\smk.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="hooks\hook_mciSendCommand.cpp">
@@ -85,6 +88,9 @@
     </ClCompile>
     <ClCompile Include="modules\sc2k_1996.cpp">
       <Filter>Source Files\Modules</Filter>
+    </ClCompile>
+    <ClCompile Include="smk.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/smk.cpp
+++ b/smk.cpp
@@ -26,7 +26,7 @@ void GetSMKFuncs() {
 	strcat_s(szSMKLibPath, MAX_PATH, "\\smackw32.dll");
 
 	hMod_SMK = LoadLibraryA(szSMKLibPath);
-	if (!hMod_SMK) {
+	if ( ((UINT)hMod_SMK) < ((UINT)HINSTANCE_ERROR) ) {
 		ConsoleLog(LOG_ERROR, "Failed to load smacker library, related hooks will be disabled.\n");
 		return;
 	}

--- a/smk.cpp
+++ b/smk.cpp
@@ -1,0 +1,53 @@
+// sc2kfix utility.cpp: utility functions to save me from reinventing the wheel
+// (c) 2025 github.com/araxestroy - released under the MIT license
+
+#undef UNICODE
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <psapi.h>
+#include <commctrl.h>
+#include <shlwapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <intrin.h>
+#include <time.h>
+
+#include <sc2kfix.h>
+
+SMKOpenPtr SMKOpenProc;
+
+static HMODULE hMod_SMK = 0;
+
+void GetSMKFuncs() {
+	char szSMKLibPath[MAX_PATH] = { 0 };
+
+	GetModuleFileNameEx(GetCurrentProcess(), NULL, szSMKLibPath, MAX_PATH);
+	PathRemoveFileSpecA(szSMKLibPath);
+	strcat_s(szSMKLibPath, MAX_PATH, "\\smackw32.dll");
+
+	hMod_SMK = LoadLibraryA(szSMKLibPath);
+	if (!hMod_SMK) {
+		ConsoleLog(LOG_ERROR, "Failed to load smacker library, related hooks will be disabled.\n");
+		return;
+	}
+
+	SMKOpenProc = (SMKOpenPtr) GetProcAddress(hMod_SMK, "_SmackOpen");
+	if (!SMKOpenProc) {
+		ConsoleLog(LOG_INFO, "Failed to load smacker open function.\n");
+
+		FreeLibrary(hMod_SMK);
+		hMod_SMK = 0;
+		return;
+	}
+
+	ConsoleLog(LOG_INFO, "Loaded smacker functions.\n");
+}
+
+void ReleaseSMKFuncs() {
+	if (hMod_SMK) {
+		ConsoleLog(LOG_INFO, "Releasing smacker functions.\n");
+
+		FreeLibrary(hMod_SMK);
+		hMod_SMK = 0;
+	}
+}


### PR DESCRIPTION
This branch deals with adjusting the passed path for the movies so:
1) It gets passed the checks in-order to avoid the "in-flight" movie notices.
2) The main function will actually play the movies.

Based on the issue https://github.com/sc2kfix/sc2kfix/issues/13 it also deals with adding a new registry key for a specific 'Movies' directory.

This has been tested on the system here without any apparent issues showing up.

If this is nothing but a guide, feel free.