### PR TITLE
Fix local movie detection and playback

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -28,6 +28,7 @@
 #define MISCHOOK_DEBUG_DISASTERS 32
 #define MISCHOOK_DEBUG_MOVIES 64
 #define MISCHOOK_DEBUG_SMACK 128
+#define MISCHOOK_DEBUG_REGISTRY 256
 
 #define MISCHOOK_DEBUG DEBUG_FLAGS_NONE
 
@@ -40,8 +41,6 @@ UINT mischook_debug = MISCHOOK_DEBUG;
 
 static DWORD dwDummy;
 
-static char def_data_path[] = "A:\\DATA\\";
-
 UINT iMilitaryBaseTries = 0;
 WORD wMilitaryBaseX = 0, wMilitaryBaseY = 0;
 
@@ -51,18 +50,23 @@ char szTempMayorName[24] = { 0 };
 char szCurrentMonthDay[24] = { 0 };
 const char* szMonthNames[12] = { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
 
-static void AdjustDefDataPathDrive() {
-	// Let's get the drive letter from
-	// the movies path.
-	const char *temp = GetSetMoviesPath();
-	if (!temp)
-		return;
-	def_data_path[0] = temp[0];
+static const char AdjustMoviePathDrive() {
+	// Let's get the drive letter from one of two paths:
+	// a) Movies path if the setting to use local movies is enabled
+	// b) Goodies path if you want to default to the presumed CD location.
+	const char *temp = (bSettingsUseLocalMovies) ? GetSetMoviesPath() : GetGoodiesPath();
+	if (!temp && !isalpha(temp[0]))
+		return 'A';
+	return temp[0];
 }
 
 // Reference and inspiration for this comes from the separate
 // 'simcity-noinstall' project.
 static const char *AdjustSource(char *buf, const char *path) {
+	static char def_data_path[] = "A:\\DATA\\";
+
+	def_data_path[0] = AdjustMoviePathDrive();
+	
 	int plen = strlen(path);
 	int flen = strlen(def_data_path);
 	if (plen <= flen || _strnicmp(def_data_path, path, flen) != 0) {
@@ -83,9 +87,27 @@ static const char *AdjustSource(char *buf, const char *path) {
 	strcat_s(buf, MAX_PATH, temp);
 
 	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Adjustment - %s -> %s\n", _ReturnAddress(), path, buf);
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Source Adjustment - %s -> %s\n", _ReturnAddress(), path, buf);
 
 	return buf;
+}
+
+extern "C" LSTATUS __stdcall Hook_RegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData) {
+	if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> RegQueryValueExA(0x%08x, %s, 0x%08X, 0x%08X, 0x%08X, 0x%08X)\n", _ReturnAddress(), hKey, lpValueName,
+			lpReserved, *lpType, lpData, lpcbData);
+
+	if (_stricmp(lpValueName, "Goodies") == 0) {
+		if (*lpType == REG_SZ) {
+			if (bSettingsUseLocalMovies) {
+				if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+					ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Query Adjustment - %s -> %s\n", _ReturnAddress(), lpValueName, "MOVIES");
+				return RegQueryValueExA(hKey, "MOVIES", lpReserved, lpType, lpData, lpcbData);
+			}
+		}
+	}
+
+	return RegQueryValueExA(hKey, lpValueName, lpReserved, lpType, lpData, lpcbData);
 }
 
 extern "C" HANDLE __stdcall Hook_CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
@@ -482,7 +504,8 @@ extern "C" int __cdecl Hook_SimulationPrepareDisaster(DWORD* a1, __int16 a2, __i
 // This should probably have a better name. And maybe be broken out into smaller functions.
 void InstallMiscHooks(void) {
 
-	AdjustDefDataPathDrive();
+	// Install RegQueryValueExA
+	*(DWORD*)(0x4EF800) = (DWORD)Hook_RegQueryValueExA;
 
 	// Install CreateFileA hook
 	*(DWORD*)(0x4EFADC) = (DWORD)Hook_CreateFileA;

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -110,6 +110,7 @@ extern BOOL bSettingsFixOrdinances;
 
 // Path functions (from registry area)
 
+const char *GetGoodiesPath();
 const char *GetSetMoviesPath();
 
 // SMK funcs


### PR DESCRIPTION
This avoids the situation that would occur if the "Goodies" registry key was pointed towards a different drive (and said drive didn't contain the "Data" directory with video files).

If you've got the "Local Movie" option set, it will instead query the "Movies" key.