### PR TITLE
Tab ordering and specific setting for skipping introduction videos

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -300,7 +300,7 @@ extern "C" DWORD __cdecl Hook_SmackOpen(LPCSTR lpFileName, uint32_t uFlags, int3
 	if (mischook_debug & MISCHOOK_DEBUG_SMACK)
 		ConsoleLog(LOG_DEBUG, "SMK:  0x%08X -> _SmackOpen(%s, %u, %i)\n", _ReturnAddress(), lpFileName, uFlags, iExBuf);
 
-	if (bSkipIntro)
+	if (bSkipIntro || bSettingsAlwaysSkipIntro)
 		if (strrchr(lpFileName, '\\'))
 			if (!strcmp(strrchr(lpFileName, '\\'), "\\INTROA.SMK") || !strcmp(strrchr(lpFileName, '\\'), "\\INTROB.SMK"))
 				return NULL;

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -102,6 +102,7 @@ extern BOOL bSettingsUseStatusDialog;
 extern BOOL bSettingsTitleCalendar;
 extern BOOL bSettingsUseNewStrings;
 extern BOOL bSettingsUseLocalMovies;
+extern BOOL bSettingsAlwaysSkipIntro;
 
 extern BOOL bSettingsMilitaryBaseRevenue;
 extern BOOL bSettingsFixOrdinances;

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -31,6 +31,7 @@ BOOL bSettingsUseStatusDialog = FALSE;
 BOOL bSettingsTitleCalendar = TRUE;
 BOOL bSettingsUseNewStrings = TRUE;
 BOOL bSettingsUseLocalMovies = TRUE;
+BOOL bSettingsAlwaysSkipIntro = FALSE;
 
 BOOL bSettingsMilitaryBaseRevenue = FALSE;	// NYI
 BOOL bSettingsFixOrdinances = FALSE;		// NYI
@@ -153,6 +154,12 @@ void LoadSettings(void) {
 		RegSetValueEx(hkeySC2KFix, "bSettingsUseLocalMovies", NULL, REG_DWORD, (BYTE*)&bSettingsUseLocalMovies, sizeof(BOOL));
 	}
 
+	dwSizeofBool = sizeof(BOOL);
+	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsAlwaysSkipIntro", RRF_RT_REG_DWORD, NULL, &bSettingsAlwaysSkipIntro, &dwSizeofBool)) {
+		bSettingsAlwaysSkipIntro = FALSE;
+		RegSetValueEx(hkeySC2KFix, "bSettingsAlwaysSkipIntro", NULL, REG_DWORD, (BYTE*)&bSettingsAlwaysSkipIntro, sizeof(BOOL));
+	}
+
 	// Gameplay mods
 
 	dwSizeofBool = sizeof(BOOL);
@@ -199,6 +206,7 @@ void SaveSettings(void) {
 	RegSetValueEx(hkeySC2KFix, "bSettingsTitleCalendar", NULL, REG_DWORD, (BYTE*)&bSettingsTitleCalendar, sizeof(BOOL));
 	RegSetValueEx(hkeySC2KFix, "bSettingsUseNewStrings", NULL, REG_DWORD, (BYTE*)&bSettingsUseNewStrings, sizeof(BOOL));
 	RegSetValueEx(hkeySC2KFix, "bSettingsUseLocalMovies", NULL, REG_DWORD, (BYTE*)&bSettingsUseLocalMovies, sizeof(BOOL));
+	RegSetValueEx(hkeySC2KFix, "bSettingsAlwaysSkipIntro", NULL, REG_DWORD, (BYTE*)&bSettingsAlwaysSkipIntro, sizeof(BOOL));
 
 	RegSetValueEx(hkeySC2KFix, "bSettingsMilitaryBaseRevenue", NULL, REG_DWORD, (BYTE*)&bSettingsMilitaryBaseRevenue, sizeof(BOOL));
 	RegSetValueEx(hkeySC2KFix, "bSettingsFixOrdinances", NULL, REG_DWORD, (BYTE*)&bSettingsFixOrdinances, sizeof(BOOL));
@@ -208,6 +216,47 @@ void SaveSettings(void) {
 	UpdateMiscHooks();
 }
 
+static void SetSettingsTabOrdering(HWND hwndDlg) {
+	UINT uFlags = (SWP_NOMOVE | SWP_NOSIZE);
+
+	// Entries are defined in reverse order.
+
+	// Bottom Buttons
+	SetWindowPos(GetDlgItem(hwndDlg, ID_SETTINGS_VANILLA), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, ID_SETTINGS_DEFAULTS), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, ID_SETTINGS_CANCEL), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, ID_SETTINGS_OK), NULL, 0, 0, 0, 0, uFlags);
+
+	// Gameplay Mod Settings
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_RADIOACTIVE_DECAY), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_FIX_ORDINANCES), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_BUILDINGS), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), NULL, 0, 0, 0, 0, uFlags);
+
+	// Interface Settings
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG), NULL, 0, 0, 0, 0, uFlags);
+
+	// sc2kfix Core Settings
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_CONSOLE), NULL, 0, 0, 0, 0, uFlags);
+
+	// Quality of Life / Performance Settings
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MP3_MUSIC), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_REFRESH_RATE), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MULTITHREADED_MUSIC), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SHUFFLE_MUSIC), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SOUND_REPLACEMENTS), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_BKGDMUSIC), NULL, 0, 0, 0, 0, uFlags);
+
+	// Game Settings
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_COMPANY), NULL, 0, 0, 0, 0, uFlags);
+	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_MAYOR), NULL, 0, 0, 0, 0, uFlags);
+}
+
 BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	std::string strVersionInfo;
 	switch (message) {
@@ -215,6 +264,8 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 		// Set the dialog box icon
 		SendMessage(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)LoadIcon(hSC2KFixModule, MAKEINTRESOURCE(IDI_TOPSECRET)));
 		SendMessage(hwndDlg, WM_SETICON, ICON_SMALL, (LPARAM)LoadIcon(hSC2KFixModule, MAKEINTRESOURCE(IDI_TOPSECRET)));
+
+		SetSettingsTabOrdering(hwndDlg);
 
 		// Create tooltips.
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, ID_SETTINGS_OK),
@@ -267,6 +318,8 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			"Certain strings in the game have typos, grammatical issues, and/or ambiguous wording. This setting loads corrected strings in memory in place of the affected originals.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES),
 			"Enabling this setting will play the introduction \"in-flight movie\" and the WillTV interview videos from the MOVIES directory, if the video files have been copied there from the install CD.");
+		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO),
+			"Once enabled the introduction videos will be skipped on startup (This will only apply if the videos have been detected, otherwise the standard warning will be displayed).");
 
 		// Gameplay mod settings
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE),
@@ -326,6 +379,7 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), bSettingsTitleCalendar ? BST_CHECKED : BST_UNCHECKED);
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), bSettingsUseNewStrings ? BST_CHECKED : BST_UNCHECKED);
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), bSettingsUseLocalMovies ? BST_CHECKED : BST_UNCHECKED);
+		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), bSettingsAlwaysSkipIntro ? BST_CHECKED : BST_UNCHECKED);
 
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), bSettingsMilitaryBaseRevenue ? BST_CHECKED : BST_UNCHECKED);
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_FIX_ORDINANCES), bSettingsFixOrdinances ? BST_CHECKED : BST_UNCHECKED);
@@ -357,6 +411,7 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			bSettingsTitleCalendar = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE));
 			bSettingsUseNewStrings = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS));
 			bSettingsUseLocalMovies = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES));
+			bSettingsAlwaysSkipIntro = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO));
 
 			bSettingsMilitaryBaseRevenue = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE));
 			bSettingsFixOrdinances = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_FIX_ORDINANCES));
@@ -384,6 +439,7 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), BST_CHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), BST_CHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), BST_CHECKED);
+			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), BST_UNCHECKED);
 
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_FIX_ORDINANCES), BST_UNCHECKED);
@@ -404,6 +460,7 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), BST_UNCHECKED);
+			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), BST_UNCHECKED);
 
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_FIX_ORDINANCES), BST_UNCHECKED);

--- a/resource.h
+++ b/resource.h
@@ -43,6 +43,7 @@
 #define IDC_STATIC_VERSIONINFO          21031
 #define IDC_SETTINGS_CHECK_LOCAL_MOVIES 21032
 #define IDC_SETTINGS_CHECK_MP3_MUSIC    21033
+#define IDC_SETTINGS_CHECK_SKIP_INTRO   21034
 #define IDR_WAVE_500                    23001
 #define IDR_WAVE_514                    23002
 #define IDR_WAVE_529                    23003
@@ -68,7 +69,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        23036
 #define _APS_NEXT_COMMAND_VALUE         40002
-#define _APS_NEXT_CONTROL_VALUE         21034
+#define _APS_NEXT_CONTROL_VALUE         21035
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/sc2kfix.rc
+++ b/sc2kfix.rc
@@ -129,11 +129,11 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,35,247,10
     CONTROL         " *Always start the sc2kfix console on game startup (Default: off)",IDC_SETTINGS_CHECK_CONSOLE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,205,247,10
-    GROUPBOX        "Gameplay Mod Settings",IDC_STATIC,277,101,261,133
+    GROUPBOX        "Gameplay Mod Settings",IDC_STATIC,277,115,261,119
     CONTROL         " *Military bases generate revenue (Default: off)",IDC_SETTINGS_CHECK_MILITARY_REVENUE,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,114,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,128,247,10
     CONTROL         " *Fully restore partially-implemented ordinances (Default: off)",IDC_SETTINGS_CHECK_FIX_ORDINANCES,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,142,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,156,247,10
     CONTROL         " *Check for sc2kfix updates on game startup (Default: on)",IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,219,247,10
     PUSHBUTTON      "Defaults",ID_SETTINGS_DEFAULTS,293,252,50,14
@@ -141,20 +141,22 @@ BEGIN
     RTEXT           "sc2kfix version 0.0-dev (tag)",IDC_STATIC_VERSIONINFO,420,262,126,8,WS_DISABLED
     CONTROL         " *Use multithreaded music engine (Default: on)",IDC_SETTINGS_CHECK_MULTITHREADED_MUSIC,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,143,247,10
-    GROUPBOX        "Interface Settings",IDC_STATIC,277,23,261,71
+    GROUPBOX        "Interface Settings",IDC_STATIC,277,23,261,85
     CONTROL         " Display full SimCalendar date in title bar (Default: on)",IDC_SETTINGS_CHECK_TITLE_DATE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,49,247,10
     CONTROL         " Display city growth in real-time instead of in batches (Default: on)",IDC_SETTINGS_CHECK_REFRESH_RATE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,157,247,10
     CONTROL         " *Use expanded list of buildings for Army bases (Default: off)",IDC_SETTINGS_CHECK_MILITARY_BUILDINGS,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,128,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,142,247,10
     CONTROL         " *Use rebalanced radioactive decay algorithm (Default: off)",IDC_SETTINGS_CHECK_RADIOACTIVE_DECAY,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,156,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,170,247,10
+    GROUPBOX        "sc2kfix Core Settings", IDC_STATIC, 7, 192, 261, 42
     CONTROL         " Use videos inside game's ""MOVIES"" directory (Default: on)",IDC_SETTINGS_CHECK_LOCAL_MOVIES,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,78,247,10
-    GROUPBOX        "sc2kfix Core Settings",IDC_STATIC,7,192,261,42
     CONTROL         " Play MP3 music instead of MIDI music if present (Default: off)",IDC_SETTINGS_CHECK_MP3_MUSIC,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,171,247,10
+    CONTROL         " Always skip introduction videos (Default: off)", IDC_SETTINGS_CHECK_SKIP_INTRO,
+                    "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 284, 92, 247, 10
 END
 
 103 DIALOGEX 0, 0, 72, 195


### PR DESCRIPTION
I saw your commit concerning the command line switch for skipping the introduction videos, definitely a good idea.

Though if desired a permanent setting has been added as well (for relative convenience).

I've also added a function for adjusting the tab ordering in the Settings dialogue.