### PR TITLE
Program Portability - All settings stored in ini file

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -151,13 +151,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 
         SetGamePath();
 
-#if STORE_DRIVE_LETTER
-        if (!FillDriveSelectionArray()) {
-            MessageBox(GetActiveWindow(), "Could not fetch drive letter list", "sc2kfix error", MB_OK | MB_ICONERROR);
-            return FALSE;
-        }
-#endif
-
         // Load settings
         if (!bSkipLoadSettings)
             LoadSettings();
@@ -365,9 +358,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 
         // Send a closing message and close the log file
         ReleaseSMKFuncs();
-#if STORE_DRIVE_LETTER
-        FreeDriveSelectionArray();
-#endif
         ConsoleLog(LOG_INFO, "CORE: Closing down at %lld. Goodnight!\n", time(NULL));
         fflush(fdLog);
         fclose(fdLog);

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -94,6 +94,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 
     switch (reason) {
     case DLL_PROCESS_ATTACH:
+        char szModuleBaseName[200];
         // Save our own module handle
         hSC2KFixModule = hModule;
 
@@ -111,6 +112,14 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
         // Retrieve the list of functions we need to hook or pass through to WinMM
         ALLEXPORTS_HOOKED(GETPROC);
         ALLEXPORTS_PASSTHROUGH(GETPROC);
+
+        // Before we do anything, check to see whether we're attaching against a valid binary
+        // (Based on the filename). Otherwise breakout.
+        GetModuleBaseName(GetCurrentProcess(), NULL, szModuleBaseName, 200);
+        if (!(_stricmp(szModuleBaseName, "winscurk.exe") == 0 ||
+        	_stricmp(szModuleBaseName, "simcity.exe") == 0)) {
+            break;
+        }
 
         // Save the SimCity 2000 EXE's module handle
         if (!(hSC2KAppModule = GetModuleHandle(NULL))) {
@@ -140,17 +149,20 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
         //      prior to the console itself being enabled.
         fopen_s(&fdLog, "sc2kfix.log", "w");
 
+        SetGamePath();
+
+#if STORE_DRIVE_LETTER
         if (!FillDriveSelectionArray()) {
-            MessageBox(GetActiveWindow(), "Could not fetch drive letter list (???)", "sc2kfix error", MB_OK | MB_ICONERROR);
+            MessageBox(GetActiveWindow(), "Could not fetch drive letter list", "sc2kfix error", MB_OK | MB_ICONERROR);
             return FALSE;
         }
-
+#endif
 
         // Load settings
         if (!bSkipLoadSettings)
             LoadSettings();
         else
-            ConsoleLog(LOG_INFO, "CORE: -default passed, skipping LoadSettings(). (%s)\n", szSettingsMovieDriveLetter);
+            ConsoleLog(LOG_INFO, "CORE: -default passed, skipping LoadSettings()\n");
 
         // Force the console to be enabled if bSettingsAlwaysConsole is set
         if (bSettingsAlwaysConsole)
@@ -195,7 +207,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
         SetUnhandledExceptionFilter(CrashHandler);
 
         // If we're attached to SCURK, switch over to the SCURK fix code
-        char szModuleBaseName[200];
         GetModuleBaseName(GetCurrentProcess(), NULL, szModuleBaseName, 200);
         if (!_stricmp(szModuleBaseName, "winscurk.exe")) {
             InjectSCURKFix();
@@ -232,8 +243,13 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
         }
 
         // Registry check
-        if (DoRegistryCheckAndInstall())
-            ConsoleLog(LOG_INFO, "CORE: Registry entries created by faux-installer.");
+        int iInstallCheck;
+
+        iInstallCheck = DoRegistryCheckAndInstall();
+        if (iInstallCheck == 2)
+            ConsoleLog(LOG_INFO, "CORE: Portable entries created by faux-installer.");
+        else if (iInstallCheck == 1)
+            ConsoleLog(LOG_INFO, "CORE: Registry entries migrated by faux-installer.");
 
         // Check for updates
         if (bSettingsCheckForUpdates) {
@@ -323,8 +339,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
         ConsoleLog(LOG_INFO, "CORE: Patched 8-bit colour warnings.\n");
 
         // Hooks we only want to inject on the 1996 Special Edition version
+        // and the registry hooks that are for the 1995 CD Collection version.
         if (dwDetectedVersion == SC2KVERSION_1996)
             InstallMiscHooks();
+        else if (dwDetectedVersion == SC2KVERSION_1995)
+            InstallRegistryPathingHooks_SC2K1995();
 
         // Start the console thread.
         if (bConsoleEnabled) {
@@ -346,7 +365,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 
         // Send a closing message and close the log file
         ReleaseSMKFuncs();
+#if STORE_DRIVE_LETTER
         FreeDriveSelectionArray();
+#endif
         ConsoleLog(LOG_INFO, "CORE: Closing down at %lld. Goodnight!\n", time(NULL));
         fflush(fdLog);
         fclose(fdLog);

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -135,14 +135,22 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
             }
         }
 
+        // Open a log file. If it fails, we handle that safely elsewhere
+        // AF - Relocated so it will record any messages that occur
+        //      prior to the console itself being enabled.
+        fopen_s(&fdLog, "sc2kfix.log", "w");
+
+        if (!FillDriveSelectionArray()) {
+            MessageBox(GetActiveWindow(), "Could not fetch drive letter list (???)", "sc2kfix error", MB_OK | MB_ICONERROR);
+            return FALSE;
+        }
+
+
         // Load settings
         if (!bSkipLoadSettings)
             LoadSettings();
         else
-            ConsoleLog(LOG_INFO, "CORE: -default passed, skipping LoadSettings().\n");
-
-        // Open a log file. If it fails, we handle that safely elsewhere
-        fopen_s(&fdLog, "sc2kfix.log", "w");
+            ConsoleLog(LOG_INFO, "CORE: -default passed, skipping LoadSettings(). (%s)\n", szSettingsMovieDriveLetter);
 
         // Force the console to be enabled if bSettingsAlwaysConsole is set
         if (bSettingsAlwaysConsole)
@@ -338,6 +346,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 
         // Send a closing message and close the log file
         ReleaseSMKFuncs();
+        FreeDriveSelectionArray();
         ConsoleLog(LOG_INFO, "CORE: Closing down at %lld. Goodnight!\n", time(NULL));
         fflush(fdLog);
         fclose(fdLog);

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -29,7 +29,6 @@
 #define MISCHOOK_DEBUG_MOVIES 64
 #define MISCHOOK_DEBUG_SMACK 128
 #define MISCHOOK_DEBUG_CHEAT 256
-#define MISCHOOK_DEBUG_REGISTRY 512
 
 #define MISCHOOK_DEBUG DEBUG_FLAGS_NONE
 
@@ -47,107 +46,6 @@ DLGPROC lpNewCityAfxProc = NULL;
 char szTempMayorName[24] = { 0 };
 char szCurrentMonthDay[24] = { 0 };
 const char* szMonthNames[12] = { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
-
-static const char AdjustMoviePathDrive() {
-	// Let's get the drive letter from one of two paths:
-	// a) Movies path if the setting to use local movies is enabled
-	// b) Goodies path if you want to default to the presumed CD location.
-	const char *temp = (bSettingsUseLocalMovies) ? GetSetMoviesPath() : GetGoodiesPath();
-	if (!temp && !isalpha(temp[0]))
-		return 'A';
-	return temp[0];
-}
-
-// Reference and inspiration for this comes from the separate
-// 'simcity-noinstall' project.
-static const char *AdjustSource(char *buf, const char *path) {
-	static char def_data_path[] = "A:\\DATA\\";
-
-	def_data_path[0] = AdjustMoviePathDrive();
-	
-	int plen = strlen(path);
-	int flen = strlen(def_data_path);
-	if (plen <= flen || _strnicmp(def_data_path, path, flen) != 0) {
-		return path;
-	}
-
-	char temp[MAX_PATH+1];
-	const char *ptemp = GetSetMoviesPath();
-	if (!ptemp) {
-		return path;
-	}
-
-	memset(temp, 0, sizeof(temp));
-
-	strcpy_s(temp, MAX_PATH, path + (flen - 1));
-
-	strcpy_s(buf, MAX_PATH, ptemp);
-	strcat_s(buf, MAX_PATH, temp);
-
-	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Source Adjustment - %s -> %s\n", _ReturnAddress(), path, buf);
-
-	return buf;
-}
-
-extern "C" LSTATUS __stdcall Hook_RegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData) {
-	if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
-		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> RegQueryValueExA(0x%08x, %s, 0x%08X, 0x%08X, 0x%08X, 0x%08X)\n", _ReturnAddress(), hKey, lpValueName,
-			lpReserved, *lpType, lpData, lpcbData);
-
-	if (_stricmp(lpValueName, "Goodies") == 0) {
-		if (*lpType == REG_SZ) {
-			if (bSettingsUseLocalMovies) {
-				if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
-					ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Query Adjustment - %s -> %s\n", _ReturnAddress(), lpValueName, "MOVIES");
-				return RegQueryValueExA(hKey, "MOVIES", lpReserved, lpType, lpData, lpcbData);
-			}
-		}
-	}
-
-	return RegQueryValueExA(hKey, lpValueName, lpReserved, lpType, lpData, lpcbData);
-}
-
-extern "C" HANDLE __stdcall Hook_CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
-	LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {
-	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> CreateFileA(%s, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X)\n", _ReturnAddress(), lpFileName,
-			dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
-	if (bSettingsUseLocalMovies) {
-		if ((DWORD)_ReturnAddress() == 0x4A8A90 ||
-			(DWORD)_ReturnAddress() == 0x48A810) {
-			char buf[MAX_PATH + 1];
-
-			memset(buf, 0, sizeof(buf));
-
-			HANDLE hFileHandle = CreateFileA(AdjustSource(buf, lpFileName), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
-			if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-				ConsoleLog(LOG_DEBUG, "MISC: (Modification): 0x%08X -> CreateFileA(%s, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X) (0x%08x)\n", _ReturnAddress(), lpFileName,
-					dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile, hFileHandle);
-			return hFileHandle;
-		}
-	}
-	return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
-}
-
-extern "C" HANDLE __stdcall Hook_FindFirstFileA(LPCSTR lpFileName, LPWIN32_FIND_DATAA lpFindFileData) {
-	if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> FindFirstFileA(%s, 0x%08X)\n", _ReturnAddress(), lpFileName, lpFindFileData);
-	if (bSettingsUseLocalMovies) {
-		if ((DWORD)_ReturnAddress() == 0x4A8A90 ||
-			(DWORD)_ReturnAddress() == 0x48A810) {
-			char buf[MAX_PATH + 1];
-
-			memset(buf, 0, sizeof(buf));
-
-			HANDLE hFileHandle = FindFirstFileA(AdjustSource(buf, lpFileName), lpFindFileData);
-			if (mischook_debug & MISCHOOK_DEBUG_OTHER)
-				ConsoleLog(LOG_DEBUG, "MISC: (Modification): 0x%08X -> FindFirstFileA(%s, 0x%08X) (0x%08x)\n", _ReturnAddress(), buf, lpFindFileData, hFileHandle);
-			return hFileHandle;
-		}
-	}
-	return FindFirstFileA(lpFileName, lpFindFileData);
-}
 
 // Override some strings that have egregiously bad grammar/capitalization.
 // Maxis fail English? That's unpossible!
@@ -469,14 +367,7 @@ extern "C" int __stdcall Hook_CSimcityView_WM_MBUTTONDOWN(WPARAM wMouseKeys, POI
 // Install hooks and run code that we only want to do for the 1996 Special Edition SIMCITY.EXE.
 // This should probably have a better name. And maybe be broken out into smaller functions.
 void InstallMiscHooks(void) {
-	// Install RegQueryValueExA
-	*(DWORD*)(0x4EF800) = (DWORD)Hook_RegQueryValueExA;
-
-	// Install CreateFileA hook
-	*(DWORD*)(0x4EFADC) = (DWORD)Hook_CreateFileA;
-
-	// Install FindFirstFileA hook
-	*(DWORD*)(0x4EFB8C) = (DWORD)Hook_FindFirstFileA;
+	InstallRegistryPathingHooks_SC2K1996();
 
 	// Install LoadStringA hook
 	*(DWORD*)(0x4EFBE8) = (DWORD)Hook_LoadStringA;

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -201,14 +201,11 @@ extern "C" DWORD __cdecl Hook_SmackOpen(LPCSTR lpFileName, uint32_t uFlags, int3
 			if (!strcmp(strrchr(lpFileName, '\\'), "\\INTROA.SMK") || !strcmp(strrchr(lpFileName, '\\'), "\\INTROB.SMK"))
 				return NULL;
 
-	if (bSettingsUseLocalMovies) {
-		char buf[MAX_PATH + 1];
+	char buf[MAX_PATH + 1];
 
-		memset(buf, 0, sizeof(buf));
+	memset(buf, 0, sizeof(buf));
 
-		return SMKOpenProc(AdjustSource(buf, lpFileName), uFlags, iExBuf);
-	}
-	return SMKOpenProc(lpFileName, uFlags, iExBuf);
+	return SMKOpenProc(AdjustSource(buf, lpFileName), uFlags, iExBuf);
 }
 
 static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -19,10 +19,6 @@
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
 // #define CONSOLE_ENABLED
 
-// Turning this on will enable the storage and setting of the drive letter, this is specifically
-// for if you want to play the videos from the CD.
-#define STORE_DRIVE_LETTER  0
-
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1
 #define SC2KVERSION_1996    2
@@ -102,10 +98,6 @@ extern char szGamePath[MAX_PATH];
 extern char szSettingsMayorName[64];
 extern char szSettingsCompanyName[64];
 
-#if STORE_DRIVE_LETTER
-extern char szSettingsMovieDriveLetter[4];
-#endif
-
 extern BOOL bSettingsMusicInBackground;
 extern BOOL bSettingsUseSoundReplacements;
 extern BOOL bSettingsShuffleMusic;
@@ -152,10 +144,6 @@ BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARA
 BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 int DoRegistryCheckAndInstall(void);
 void SetGamePath(void);
-#if STORE_DRIVE_LETTER
-bool FillDriveSelectionArray(void);
-void FreeDriveSelectionArray(void);
-#endif
 const char *GetIniPath();
 void LoadSettings(void);
 void SaveSettings(BOOL onload);

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -19,12 +19,21 @@
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
 #define CONSOLE_ENABLED
 
+// Turning this on will enable the storage and setting of the drive letter, this is specifically
+// for if you want to play the videos from the CD.
+#define STORE_DRIVE_LETTER  0
+
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1
 #define SC2KVERSION_1996    2
 
 #define SC2KFIX_VERSION		"0.9a"
 #define SC2KFIX_RELEASE_TAG	"r9a"
+
+#define SC2KFIX_INIFILE     "sc2kfix.ini"
+
+#define countof(x) (sizeof(x)/sizeof(*(x)))
+#define lengthof(s) (countof(s)-1)
 
 #define RELATIVE_OFFSET(from, to) *(DWORD*)((DWORD)(from)) = (DWORD)(to) - (DWORD)(from) - 4;
 #define NEWCALL(from, to) *(BYTE*)(from) = 0xE8; RELATIVE_OFFSET((DWORD)(from)+1, to)
@@ -84,12 +93,18 @@ enum {
 	LOG_DEBUG
 };
 
+// Game path global
+
+extern char szGamePath[MAX_PATH];
+
 // Settings globals
 
 extern char szSettingsMayorName[64];
 extern char szSettingsCompanyName[64];
 
+#if STORE_DRIVE_LETTER
 extern char szSettingsMovieDriveLetter[4];
+#endif
 
 extern BOOL bSettingsMusicInBackground;
 extern BOOL bSettingsUseSoundReplacements;
@@ -110,10 +125,9 @@ extern BOOL bSettingsAlwaysSkipIntro;
 extern BOOL bSettingsMilitaryBaseRevenue;
 extern BOOL bSettingsFixOrdinances;
 
-// Path functions (from registry area)
+// Path adjustment (from registry_pathing area)
 
-const char *GetGoodiesPath();
-const char *GetSetMoviesPath();
+const char *AdjustSource(char *buf, const char *path);
 
 // Utility functions
 
@@ -126,17 +140,25 @@ const char* GetZoneName(int iZoneID);
 const char* GetLowHighScale(BYTE bScale);
 BOOL FileExists(const char* name);
 HBITMAP CreateSpriteBitmap(int iSpriteID);
+BOOL WritePrivateProfileIntA(const char *section, const char *name, int value, const char *ini_name);
+void MigrateRegStringValue(HKEY hKey, const char *lpSubKey, const char *lpValueName, char *szOutBuf, DWORD dwLen);
+void MigrateRegDWORDValue(HKEY hKey, const char *lpSubKey, const char *lpValueName, DWORD *dwOut, DWORD dwSize);
+void MigrateRegBOOLValue(HKEY hKey, const char *lpSubKey, const char *lpValueName, BOOL *bOut);
 
 // Globals etc.
 
 LONG WINAPI CrashHandler(LPEXCEPTION_POINTERS lpExceptions);
 BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
-BOOL DoRegistryCheckAndInstall(void);
+int DoRegistryCheckAndInstall(void);
+void SetGamePath(void);
+#if STORE_DRIVE_LETTER
 bool FillDriveSelectionArray(void);
 void FreeDriveSelectionArray(void);
+#endif
+const char *GetIniPath();
 void LoadSettings(void);
-void SaveSettings(void);
+void SaveSettings(BOOL onload);
 void ShowSettingsDialog(void);
 HWND ShowStatusDialog(void);
 void LoadReplacementSounds(void);
@@ -212,6 +234,11 @@ extern "C" int __stdcall Hook_MusicPlayNextRefocusSong(void);
 extern "C" int __stdcall Hook_402793(int iStatic, char* szText, int iMaybeAlways1, COLORREF crColor);
 extern "C" int __stdcall Hook_4021A8(HWND iShow);
 extern "C" int __stdcall Hook_40103C(int iShow);
+
+// Registry hooks
+void InstallRegistryPathingHooks_SC2K1996(void);
+void InstallRegistryPathingHooks_SC2K1995(void);
+void InstallRegistryPathingHooks_SCURK1996(void);
 
 // Debugging settings
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -14,10 +14,10 @@
 #include <music.h>
 
 // Turning this on enables every debugging option. You have been warned.
-#define DEBUGALL
+// #define DEBUGALL
 
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
-#define CONSOLE_ENABLED
+// #define CONSOLE_ENABLED
 
 // Turning this on will enable the storage and setting of the drive letter, this is specifically
 // for if you want to play the videos from the CD.

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -14,10 +14,10 @@
 #include <music.h>
 
 // Turning this on enables every debugging option. You have been warned.
-// #define DEBUGALL
+#define DEBUGALL
 
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
-// #define CONSOLE_ENABLED
+#define CONSOLE_ENABLED
 
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1
@@ -85,8 +85,11 @@ enum {
 };
 
 // Settings globals
+
 extern char szSettingsMayorName[64];
 extern char szSettingsCompanyName[64];
+
+extern char szSettingsMovieDriveLetter[4];
 
 extern BOOL bSettingsMusicInBackground;
 extern BOOL bSettingsUseSoundReplacements;
@@ -130,6 +133,8 @@ LONG WINAPI CrashHandler(LPEXCEPTION_POINTERS lpExceptions);
 BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 BOOL DoRegistryCheckAndInstall(void);
+bool FillDriveSelectionArray(void);
+void FreeDriveSelectionArray(void);
 void LoadSettings(void);
 void SaveSettings(void);
 void ShowSettingsDialog(void);

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -111,7 +111,6 @@ extern BOOL bSettingsCheckForUpdates;
 extern BOOL bSettingsUseStatusDialog;
 extern BOOL bSettingsTitleCalendar;
 extern BOOL bSettingsUseNewStrings;
-extern BOOL bSettingsUseLocalMovies;
 extern BOOL bSettingsAlwaysSkipIntro;
 
 extern BOOL bSettingsMilitaryBaseRevenue;

--- a/modules/registry_install.cpp
+++ b/modules/registry_install.cpp
@@ -74,7 +74,7 @@ static void InstallSC2KDefaults(void) {
 	WritePrivateProfileIntA(section, "AutoGoto", TRUE, ini_file);
 	WritePrivateProfileIntA(section, "AutoBudget", FALSE, ini_file);
 	WritePrivateProfileIntA(section, "AutoSave", FALSE, ini_file);
-	WritePrivateProfileIntA(section, "Speed", FALSE, ini_file);
+	WritePrivateProfileIntA(section, "Speed", 2, ini_file);
 
 	// Write default SCURK options
 	section = "SCURK";

--- a/modules/registry_install.cpp
+++ b/modules/registry_install.cpp
@@ -183,6 +183,7 @@ static void MigrateFinalize(void) {
 }
 
 int DoRegistryCheckAndInstall(void) {
+	int ret;
 	HKEY hKeySC2KRegistration;
 	LSTATUS lResultRegistration = RegOpenKeyExA(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Registration", NULL, KEY_ALL_ACCESS, &hKeySC2KRegistration);
 	if (lResultRegistration != ERROR_SUCCESS) {
@@ -191,6 +192,7 @@ int DoRegistryCheckAndInstall(void) {
 		return 0;
 	}
 
+	ret = 0;
 	if (szSettingsMayorName[0] == 0 ||
 		szSettingsCompanyName[0] == 0) {
 		if (RegQueryValueEx(hKeySC2KRegistration, "Mayor Name", NULL, NULL, NULL, NULL) == ERROR_FILE_NOT_FOUND ||
@@ -200,16 +202,13 @@ int DoRegistryCheckAndInstall(void) {
 
 			InstallSC2KDefaults();
 
-			RegCloseKey(hKeySC2KRegistration);
-
 			// Signal that we had to fake an install.
-			return 2;
+			ret = 2;
 		}
 		else {
 
 			// Migrate from registry to ini.
 			MigrateSC2KRegistration(hKeySC2KRegistration);
-			RegCloseKey(hKeySC2KRegistration);
 
 			MigrateSC2KVersion();
 			MigrateSC2KLocalize();
@@ -218,8 +217,10 @@ int DoRegistryCheckAndInstall(void) {
 			MigrateFinalize();
 
 			SaveSettings(TRUE);
-			return 1;
+			ret = 1;
 		}
 	}
-	return 0;
+
+	RegCloseKey(hKeySC2KRegistration);
+	return ret;
 }

--- a/modules/registry_install.cpp
+++ b/modules/registry_install.cpp
@@ -11,18 +11,6 @@
 #include <sc2kfix.h>
 #include "../resource.h"
 
-char szSC2KPath[MAX_PATH];
-char szSC2KGoodiesPath[MAX_PATH];
-char szSC2KMoviesPath[MAX_PATH];
-
-const char *GetGoodiesPath() {
-	return szSC2KGoodiesPath;
-}
-
-const char *GetSetMoviesPath() {
-	return szSC2KMoviesPath;
-}
-
 BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	switch (message) {
 	case WM_INITDIALOG:
@@ -53,144 +41,185 @@ BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARA
 	return FALSE;
 }
 
-BOOL DoRegistryCheckAndInstall(void) {
-	HKEY hkeySC2KRegistration;
-	LSTATUS lResultRegistration = RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Registration", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KRegistration, NULL);
+static void InstallSC2KDefaults(void) {
+	const char *ini_file = GetIniPath();
+	const char *section;
+
+	section = "Portable";
+	if (GetPrivateProfileIntA(section, "Installed", 0, ini_file) == 1) {
+		return;
+	}
+
+	WritePrivateProfileIntA(section, "Installed", 1, ini_file);
+
+	// Prompt the user for the mayor and company names
+	DialogBox(hSC2KFixModule, MAKEINTRESOURCE(IDD_INSTALL), NULL, InstallDialogProc);
+
+	// Write version info
+	DWORD dwSC2KVersion = 0x00000100;
+
+	section = "Version";
+	WritePrivateProfileIntA(section, "SCURK", dwSC2KVersion, ini_file);
+	WritePrivateProfileIntA(section, "SimCity 2000", dwSC2KVersion, ini_file);
+
+	// Write language info
+	section = "Localize";
+	WritePrivateProfileStringA(section, "Language", "USA", ini_file);
+
+	// Write default options
+	section = "Options";
+	WritePrivateProfileIntA(section, "Disasters", TRUE, ini_file);
+	WritePrivateProfileIntA(section, "Music", TRUE, ini_file);
+	WritePrivateProfileIntA(section, "Sound", TRUE, ini_file);
+	WritePrivateProfileIntA(section, "AutoGoto", TRUE, ini_file);
+	WritePrivateProfileIntA(section, "AutoBudget", FALSE, ini_file);
+	WritePrivateProfileIntA(section, "AutoSave", FALSE, ini_file);
+	WritePrivateProfileIntA(section, "Speed", FALSE, ini_file);
+
+	// Write default SCURK options
+	section = "SCURK";
+	WritePrivateProfileIntA(section, "CycleColors", 1, ini_file);
+	WritePrivateProfileIntA(section, "GridHeight", 2, ini_file);
+	WritePrivateProfileIntA(section, "GridWidth", 2, ini_file);
+	WritePrivateProfileIntA(section, "ShowClipRegion", 0, ini_file);
+	WritePrivateProfileIntA(section, "ShowDrawGrid", 0, ini_file);
+	WritePrivateProfileIntA(section, "SnapToGrid", 0, ini_file);
+	WritePrivateProfileIntA(section, "Sound", 1, ini_file);
+
+	SaveSettings(TRUE);
+}
+
+static void MigrateSC2KRegistration(HKEY hKeySC2KReg) {
+	const char *ini_file = GetIniPath();
+	const char *section = "Registration";
+
+	MigrateRegStringValue(hKeySC2KReg, NULL, "Mayor Name", szSettingsMayorName, sizeof(szSettingsMayorName));
+	WritePrivateProfileStringA(section, "Mayor Name", szSettingsMayorName, ini_file);
+
+	MigrateRegStringValue(hKeySC2KReg, NULL, "Company Name", szSettingsCompanyName, sizeof(szSettingsCompanyName));
+	WritePrivateProfileStringA(section, "Company Name", szSettingsCompanyName, ini_file);
+}
+
+static void MigrateSC2KVersion(void) {
+	DWORD dwOut;
+	const char *ini_file = GetIniPath();
+	const char *section = "Version";
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Version", "SCURK", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "SCURK", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Version", "SimCity 2000", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "SimCity 2000", dwOut, ini_file);
+}
+
+static void MigrateSC2KLocalize(void) {
+	const char *ini_file = GetIniPath();
+	const char *section = "Localize";
+
+	char szOutBuf[16];
+	MigrateRegStringValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Localize", "Language", szOutBuf, sizeof(szOutBuf));
+	WritePrivateProfileStringA(section, "Language", szOutBuf, ini_file);
+}
+
+static void MigrateSC2KOptions(void) {
+	DWORD dwOut;
+	const char *ini_file = GetIniPath();
+	const char *section = "Options";
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "Disasters", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "Disasters", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "Music", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "Music", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "Sound", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "Sound", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "AutoGoto", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "AutoGoto", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "AutoBudget", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "AutoBudget", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "AutoSave", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "AutoSave", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", "Speed", &dwOut, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "Speed", dwOut, ini_file);
+}
+
+static void MigrateSC2KSCURK(void) {
+	DWORD dwOut;
+	const char *ini_file = GetIniPath();
+	const char *section = "SCURK";
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "CycleColors", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "CycleColors", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "GridHeight", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "GridHeight", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "GridWidth", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "GridWidth", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "ShowClipRegion", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "ShowClipRegion", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "ShowDrawGrid", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "ShowDrawGrid", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "SnapToGrid", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "SnapToGrid", dwOut, ini_file);
+
+	MigrateRegDWORDValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\SCURK", "Sound", &dwOut, sizeof(DWORD));
+	WritePrivateProfileIntA(section, "Sound", dwOut, ini_file);
+}
+
+static void MigrateFinalize(void) {
+	const char *ini_file = GetIniPath();
+	const char *section = "Portable";
+
+	WritePrivateProfileIntA(section, "Installed", 1, ini_file);
+}
+
+int DoRegistryCheckAndInstall(void) {
+	HKEY hKeySC2KRegistration;
+	LSTATUS lResultRegistration = RegOpenKeyExA(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Registration", NULL, KEY_ALL_ACCESS, &hKeySC2KRegistration);
 	if (lResultRegistration != ERROR_SUCCESS) {
-		MessageBox(NULL, "Couldn't open registry keys for editing", "sc2kfix error", MB_OK | MB_ICONEXCLAMATION);
-		ConsoleLog(LOG_ERROR, "CORE: Couldn't open registry keys for registry check, error = 0x%08X\n", lResultRegistration);
-		return FALSE;
+		// Let's install.
+		InstallSC2KDefaults();
+		return 0;
 	}
 
-	if (RegQueryValueEx(hkeySC2KRegistration, "Mayor Name", NULL, NULL, NULL, NULL) == ERROR_FILE_NOT_FOUND ||
-		RegQueryValueEx(hkeySC2KRegistration, "Company Name", NULL, NULL, NULL, NULL) == ERROR_FILE_NOT_FOUND) {
+	if (szSettingsMayorName[0] == 0 ||
+		szSettingsCompanyName[0] == 0) {
+		if (RegQueryValueEx(hKeySC2KRegistration, "Mayor Name", NULL, NULL, NULL, NULL) == ERROR_FILE_NOT_FOUND ||
+			RegQueryValueEx(hKeySC2KRegistration, "Company Name", NULL, NULL, NULL, NULL) == ERROR_FILE_NOT_FOUND) {
 
-		// Fake an install.
-		
-		// Prompt the user for the mayor and company names
-		DialogBox(hSC2KFixModule, MAKEINTRESOURCE(IDD_INSTALL), NULL, InstallDialogProc);
+			// Fake an install.
 
-		// Write registration strings
-		RegSetValueEx(hkeySC2KRegistration, "Mayor Name", NULL, REG_SZ, (BYTE*)szSettingsMayorName, strlen(szSettingsMayorName) + 1);
-		RegSetValueEx(hkeySC2KRegistration, "Company Name", NULL, REG_SZ, (BYTE*)szSettingsCompanyName, strlen(szSettingsCompanyName) + 1);
+			InstallSC2KDefaults();
 
-		// Generate paths
-		char szSC2KExePath[MAX_PATH] = { 0 };
-		char szSC2KPaths[10][MAX_PATH];
-		GetModuleFileNameEx(GetCurrentProcess(), NULL, szSC2KExePath, MAX_PATH);
-		PathRemoveFileSpecA(szSC2KExePath);
-		
-		for (int i = 0; i < 10; i++)
-			strcpy_s(szSC2KPaths[i], MAX_PATH, szSC2KExePath);
+			RegCloseKey(hKeySC2KRegistration);
 
-		strcat_s(szSC2KPaths[0], MAX_PATH, "\\CITIES");
-		strcat_s(szSC2KPaths[1], MAX_PATH, "\\DATA");
-		strcat_s(szSC2KPaths[2], MAX_PATH, "\\GOODIES");
-		strcat_s(szSC2KPaths[3], MAX_PATH, "\\BITMAPS");
-		strcat_s(szSC2KPaths[4], MAX_PATH, "");
-		strcat_s(szSC2KPaths[5], MAX_PATH, "\\SOUNDS");
-		strcat_s(szSC2KPaths[6], MAX_PATH, "\\CITIES");
-		strcat_s(szSC2KPaths[7], MAX_PATH, "\\SCENARIO");
-		strcat_s(szSC2KPaths[8], MAX_PATH, "\\SCURKART");
-		strcat_s(szSC2KPaths[9], MAX_PATH, "\\Movies");
-
-		strcpy_s(szSC2KGoodiesPath, MAX_PATH, szSC2KPaths[2]);
-		strcpy_s(szSC2KMoviesPath, MAX_PATH, szSC2KPaths[9]);
-
-		// Write paths
-		HKEY hkeySC2KPaths;
-		RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Paths", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KPaths, NULL);
-		RegSetValueEx(hkeySC2KPaths, "Cities", NULL, REG_SZ, (BYTE*)szSC2KPaths[0], strlen(szSC2KPaths[0]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Data", NULL, REG_SZ, (BYTE*)szSC2KPaths[1], strlen(szSC2KPaths[1]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Goodies", NULL, REG_SZ, (BYTE*)szSC2KPaths[2], strlen(szSC2KPaths[2]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Graphics", NULL, REG_SZ, (BYTE*)szSC2KPaths[3], strlen(szSC2KPaths[3]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Home", NULL, REG_SZ, (BYTE*)szSC2KPaths[4], strlen(szSC2KPaths[4]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Music", NULL, REG_SZ, (BYTE*)szSC2KPaths[5], strlen(szSC2KPaths[5]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "SaveGame", NULL, REG_SZ, (BYTE*)szSC2KPaths[6], strlen(szSC2KPaths[6]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Scenarios", NULL, REG_SZ, (BYTE*)szSC2KPaths[7], strlen(szSC2KPaths[7]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "TileSets", NULL, REG_SZ, (BYTE*)szSC2KPaths[8], strlen(szSC2KPaths[8]) + 1);
-		RegSetValueEx(hkeySC2KPaths, "Movies", NULL, REG_SZ, (BYTE*)szSC2KPaths[9], strlen(szSC2KPaths[9]) + 1);
-
-		// Write version info
-		HKEY hkeySC2KVersion;
-		DWORD dwSC2KVersion = 0x00000100;
-		RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Version", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KVersion, NULL);
-		RegSetValueEx(hkeySC2KVersion, "SCURK", NULL, REG_DWORD, ((BYTE*)&dwSC2KVersion), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KVersion, "SimCity 2000", NULL, REG_DWORD, ((BYTE*)&dwSC2KVersion), sizeof(DWORD));
-
-		// Write language info
-		HKEY hkeySC2KLocalize;
-		RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Localize", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KLocalize, NULL);
-		RegSetValueEx(hkeySC2KLocalize, "Language", NULL, REG_SZ, ((BYTE*)"USA"), sizeof("USA"));
-
-		// Write default settings
-		HKEY hkeySC2KOptions;
-		DWORD dwTrue = 0x00000001;
-		DWORD dwFalse = 0x00000000;
-		RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Options", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KOptions, NULL);
-		RegSetValueEx(hkeySC2KOptions, "Disasters", NULL, REG_DWORD, ((BYTE*)&dwTrue), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KOptions, "Music", NULL, REG_DWORD, ((BYTE*)&dwTrue), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KOptions, "Sound", NULL, REG_DWORD, ((BYTE*)&dwTrue), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KOptions, "AutoGoto", NULL, REG_DWORD, ((BYTE*)&dwTrue), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KOptions, "AutoBudget", NULL, REG_DWORD, ((BYTE*)&dwFalse), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KOptions, "AutoSave", NULL, REG_DWORD, ((BYTE*)&dwFalse), sizeof(DWORD));
-		RegSetValueEx(hkeySC2KOptions, "Speed", NULL, REG_DWORD, ((BYTE*)&dwFalse), sizeof(DWORD));
-
-		// Signal that we had to fake an install.
-		return TRUE;
-	} else {
-		LSTATUS retval;
-
-		HKEY hkeySC2KPaths;
-		LRESULT lResultPaths = RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Paths", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KPaths, NULL);
-		if (lResultPaths != ERROR_SUCCESS) {
-			MessageBox(NULL, "Couldn't open path registry keys for editing", "sc2kfix error", MB_OK | MB_ICONEXCLAMATION);
-			ConsoleLog(LOG_ERROR, "CORE: Couldn't open path registry keys for load, error = 0x%08X\n", lResultPaths);
-			return FALSE;
+			// Signal that we had to fake an install.
+			return 2;
 		}
+		else {
 
-		// Generate paths
-		char szSC2KExePath[MAX_PATH] = { 0 };
-		GetModuleFileNameEx(GetCurrentProcess(), NULL, szSC2KExePath, MAX_PATH);
-		PathRemoveFileSpecA(szSC2KExePath);
+			// Migrate from registry to ini.
+			MigrateSC2KRegistration(hKeySC2KRegistration);
+			RegCloseKey(hKeySC2KRegistration);
 
-		DWORD dwSC2KGoodiesPathSize = MAX_PATH;
-		retval = RegGetValue(hkeySC2KPaths, NULL, "Goodies", RRF_RT_REG_SZ, NULL, szSC2KGoodiesPath, &dwSC2KGoodiesPathSize);
-		switch (retval) {
-		case ERROR_SUCCESS:
-			break;
-		default:
-			// Generate path - This will default to your main game directory.
-			strcpy_s(szSC2KGoodiesPath, szSC2KExePath);
-			strcat_s(szSC2KGoodiesPath, MAX_PATH, "\\GOODIES");
+			MigrateSC2KVersion();
+			MigrateSC2KLocalize();
+			MigrateSC2KOptions();
+			MigrateSC2KSCURK();
+			MigrateFinalize();
 
-			RegSetValueEx(hkeySC2KPaths, "Goodies", NULL, REG_SZ, (BYTE*)szSC2KGoodiesPath, strlen(szSC2KGoodiesPath) + 1);
-
-			char* buf;
-			FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, retval, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
-			ConsoleLog(LOG_WARNING, "CORE: Error loading 'Goodies' path; resetting to default. Reg: %s", buf); // The lack of the newline is deliberate.
-
-			break;
-		}
-
-		DWORD dwSC2KMoviesPathSize = MAX_PATH;
-		retval = RegGetValue(hkeySC2KPaths, NULL, "Movies", RRF_RT_REG_SZ, NULL, szSC2KMoviesPath, &dwSC2KMoviesPathSize);
-		switch (retval) {
-		case ERROR_SUCCESS:
-			break;
-		default:
-			// Generate path
-			strcpy_s(szSC2KMoviesPath, szSC2KExePath);
-			strcat_s(szSC2KMoviesPath, MAX_PATH, "\\MOVIES");
-
-			RegSetValueEx(hkeySC2KPaths, "Movies", NULL, REG_SZ, (BYTE*)szSC2KMoviesPath, strlen(szSC2KMoviesPath) + 1);
-
-			char* buf;
-			FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, retval, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
-			ConsoleLog(LOG_WARNING, "CORE: Error loading 'Movies' path; resetting to default. Reg: %s", buf); // The lack of the newline is deliberate.
-
-			break;
+			SaveSettings(TRUE);
+			return 1;
 		}
 	}
-	return FALSE;
+	return 0;
 }

--- a/modules/registry_pathing.cpp
+++ b/modules/registry_pathing.cpp
@@ -154,9 +154,6 @@ static const char *GetSetMoviesPath() {
 }
 
 static const char AdjustMoviePathDrive() {
-	// Let's get the drive letter from one of two paths:
-	// a) Movies path if the setting to use local movies is enabled
-	// b) See Below **
 	if (bSettingsUseLocalMovies) {
 		const char *temp = GetSetMoviesPath();
 		if (!temp && !isalpha(temp[0]))
@@ -164,17 +161,7 @@ static const char AdjustMoviePathDrive() {
 		return temp[0];
 	}
 
-#if STORE_DRIVE_LETTER
-	// ** Stored drive letter that'll point towards
-	// the drive that contains the 'Goodies' directory
-	// which will then contain 'DATA' at its root.
-	// The purpose of this is so you can manually
-	// target the 'right' drive that would normally
-	// contain your SimCity 2000 CD.
-	return szSettingsMovieDriveLetter[0];
-#else
 	return szGamePath[0];
-#endif
 }
 
 // Reference and inspiration for this comes from the separate

--- a/modules/registry_pathing.cpp
+++ b/modules/registry_pathing.cpp
@@ -1,0 +1,457 @@
+// sc2kfix registry_pathing.cpp: internal registry and pathing handling
+// (c) 2025 sc2kfix project (https://sc2kfix.net) - released under the MIT license
+
+#undef UNICODE
+#include <windows.h>
+#include <psapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <intrin.h>
+#include <map>
+#include <string>
+
+#include <sc2kfix.h>
+#include "../resource.h"
+
+#pragma intrinsic(_ReturnAddress)
+
+#define MISCHOOK_DEBUG_REGISTRY 32768
+#define MISCHOOK_DEBUG_PATHING 65536
+
+#define REG_KEY_BASE 0x80000040UL
+
+enum redirected_keys_t {
+	enMaxisKey,
+	enSC2KKey,
+	enPathsKey,
+	enWindowsKey,
+	enVersionKey,
+	enOptionsKey,
+	enLocalizeKey,
+	enRegistrationKey,
+	enSCURKKey,
+
+	enCountKey
+};
+
+static int iRegPathHookMode = -1; // -1 - Unknown, 0 - SC2K1996, 1 - SC2K1995, 2 - SCURK1996 (Special Edition)
+
+static BOOL IsRegKey(HKEY hKey, redirected_keys_t rkVal) {
+	if (rkVal < enMaxisKey || 
+		rkVal >= enCountKey) {
+		return FALSE;
+	}
+
+	if (hKey == (HKEY)(REG_KEY_BASE + (rkVal))) {
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+static BOOL IsFakeRegKey(unsigned long ulKey) {
+	if ((ulKey) >= (REG_KEY_BASE + enMaxisKey) &&
+		(ulKey) < (REG_KEY_BASE + enCountKey)) {
+		return TRUE;
+	}
+
+	return FALSE;
+}
+
+static BOOL RegLookup(const char *lpSubKey, unsigned long *ulKey) {
+	BOOL ret;
+
+	ret = FALSE;
+	if (strcmp(lpSubKey, "Maxis") == 0) {
+		*ulKey = enMaxisKey;
+		ret = TRUE;
+	}
+	else if (strcmp(lpSubKey, "SimCity 2000") == 0) {
+		*ulKey = enSC2KKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "Paths") == 0) {
+		*ulKey = enPathsKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "Windows") == 0) {
+		*ulKey = enWindowsKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "Version") == 0) {
+		*ulKey = enVersionKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "Options") == 0) {
+		*ulKey = enOptionsKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "Localize") == 0) {
+		*ulKey = enLocalizeKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "Registration") == 0) {
+		*ulKey = enRegistrationKey;
+		ret = TRUE;
+	}
+	else if (_stricmp(lpSubKey, "SCURK") == 0) {
+		*ulKey = enSCURKKey;
+		ret = TRUE;
+	}
+	return ret;
+}
+
+static void GetOutString(const char *sString, LPBYTE lpData, LPDWORD lpcbData) {
+	if (lpData == NULL) {
+		*lpcbData = strlen(sString) + 1;
+	}
+	else {
+		memcpy(lpData, sString, *lpcbData);
+	}
+}
+
+static void GetOutDWORD(DWORD dwValue, LPBYTE lpData, LPDWORD lpcbData) {
+	if (lpData == NULL) {
+		*lpcbData = sizeof(DWORD);
+	}
+	else {
+		memcpy(lpData, &dwValue, sizeof(DWORD));
+	}
+}
+
+static const char *GetSetMoviesPath() {
+	static char szTargetPath[MAX_PATH];
+
+	sprintf_s(szTargetPath, MAX_PATH, "%s\\Movies", szGamePath);
+	return szTargetPath;
+}
+
+static const char AdjustMoviePathDrive() {
+	// Let's get the drive letter from one of two paths:
+	// a) Movies path if the setting to use local movies is enabled
+	// b) See Below **
+	if (bSettingsUseLocalMovies) {
+		const char *temp = GetSetMoviesPath();
+		if (!temp && !isalpha(temp[0]))
+			return 'A';
+		return temp[0];
+	}
+
+#if STORE_DRIVE_LETTER
+	// ** Stored drive letter that'll point towards
+	// the drive that contains the 'Goodies' directory
+	// which will then contain 'DATA' at its root.
+	// The purpose of this is so you can manually
+	// target the 'right' drive that would normally
+	// contain your SimCity 2000 CD.
+	return szSettingsMovieDriveLetter[0];
+#else
+	return szGamePath[0];
+#endif
+}
+
+// Reference and inspiration for this comes from the separate
+// 'simcity-noinstall' project.
+const char *AdjustSource(char *buf, const char *path) {
+	static char def_data_path[] = "A:\\DATA\\";
+
+	def_data_path[0] = AdjustMoviePathDrive();
+
+	int plen = strlen(path);
+	int flen = strlen(def_data_path);
+	if (plen <= flen || _strnicmp(def_data_path, path, flen) != 0) {
+		return path;
+	}
+
+	char temp[MAX_PATH + 1];
+	const char *ptemp = GetSetMoviesPath();
+	if (!ptemp) {
+		return path;
+	}
+
+	memset(temp, 0, sizeof(temp));
+
+	strcpy_s(temp, MAX_PATH, path + (flen - 1));
+
+	strcpy_s(buf, MAX_PATH, ptemp);
+	strcat_s(buf, MAX_PATH, temp);
+
+	if (mischook_debug & MISCHOOK_DEBUG_PATHING)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Source Adjustment - %s -> %s\n", _ReturnAddress(), path, buf);
+
+	return buf;
+}
+
+static void GamePathAdjust(const char *szBasePath, const char *target, LPBYTE lpData, LPDWORD lpcbData) {
+	char szTarget[MAX_PATH];
+
+	sprintf_s(szTarget, MAX_PATH, "%s\\%s", szBasePath, target);
+	ConsoleLog(LOG_DEBUG, "[%s]\n", szTarget);
+	GetOutString(szTarget, lpData, lpcbData);
+}
+
+static void GetIniOutString(const char *section, const char *key, const char *sValue, LPBYTE lpData, LPDWORD lpcbData) {
+	const char *ini_file = GetIniPath();
+
+	char szBuf[64];
+	GetPrivateProfileStringA(section, key, sValue, szBuf, sizeof(szBuf) - 1, ini_file);
+	GetOutString(szBuf, lpData, lpcbData);
+}
+
+static void GetIniOutDWORD(const char *section, const char *key, DWORD dvVal, LPBYTE lpData, LPDWORD lpcbData) {
+	const char *ini_file = GetIniPath();
+
+	GetOutDWORD(GetPrivateProfileIntA(section, key, dvVal, ini_file), lpData, lpcbData);
+}
+
+extern "C" LSTATUS __stdcall Hook_RegSetValueExA(HKEY hKey, LPCSTR lpValueName, DWORD Reserved, DWORD dwType, const BYTE *lpData, DWORD cbData) {
+	if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> RegSetValueExA(0x%08x, %s, 0x%08X, 0x%08X, 0x%08X, 0x%08X)\n", _ReturnAddress(), hKey, lpValueName,
+			Reserved, dwType, *lpData, cbData);
+
+	return RegSetValueExA(hKey, lpValueName, Reserved, dwType, lpData, cbData);
+}
+
+extern "C" LSTATUS __stdcall Hook_RegQueryValueExA(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved, LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData) {
+	
+
+	if (IsRegKey(hKey, enPathsKey)) {
+		char szTargetPath[MAX_PATH];
+
+		strcpy_s(szTargetPath, MAX_PATH, szGamePath);
+		if (_stricmp(lpValueName, "Goodies") == 0) {
+			if (bSettingsUseLocalMovies) {
+				if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+					ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> Query Adjustment - %s -> %s\n", _ReturnAddress(), lpValueName, "MOVIES");
+				GamePathAdjust(szTargetPath, "Movies", lpData, lpcbData);
+			}
+			else {
+				szTargetPath[0] = AdjustMoviePathDrive();
+				GamePathAdjust(szTargetPath, "Goodies", lpData, lpcbData);
+			}
+		}
+		else if (_stricmp(lpValueName, "Cities") == 0 ||
+			_stricmp(lpValueName, "SaveGame") == 0) {
+			GamePathAdjust(szTargetPath, "Cities", lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Data") == 0) {
+			GamePathAdjust(szTargetPath, "Data", lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Graphics") == 0) {
+			GamePathAdjust(szTargetPath, "Bitmaps", lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Home") == 0) {
+			ConsoleLog(LOG_DEBUG, "[%s]\n", szTargetPath);
+			GetOutString(szTargetPath, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Music") == 0) {
+			GamePathAdjust(szTargetPath, "Sounds", lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Scenarios") == 0) {
+			GamePathAdjust(szTargetPath, "Scenario", lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "TileSets") == 0) {
+			GamePathAdjust(szTargetPath, "ScurkArt", lpData, lpcbData);
+		}
+		return ERROR_SUCCESS;
+	}
+
+	if (IsRegKey(hKey, enVersionKey)) {
+		if (_stricmp(lpValueName, "SimCity 2000") == 0) {
+			GetIniOutDWORD("Version", lpValueName, 256, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "SCURK") == 0) {
+			GetIniOutDWORD("Version", lpValueName, 256, lpData, lpcbData);
+		}
+		return ERROR_SUCCESS;
+	}
+
+	if (IsRegKey(hKey, enWindowsKey)) {
+		if (_stricmp(lpValueName, "Display") == 0) {
+			GetIniOutString("Windows", lpValueName, "8 1", lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Color Check") == 0) {
+			GetIniOutDWORD("Windows", lpValueName, 0, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Last Color Depth") == 0) {
+			GetIniOutDWORD("Windows", lpValueName, 20, lpData, lpcbData);
+		}
+		return ERROR_SUCCESS;
+	}
+
+	if (IsRegKey(hKey, enRegistrationKey)) {
+		if (_stricmp(lpValueName, "Mayor Name") == 0) {
+			GetIniOutString("Registration", lpValueName, szSettingsMayorName, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Company Name") == 0) {
+			GetIniOutString("Registration", lpValueName, szSettingsCompanyName, lpData, lpcbData);
+		}
+		return ERROR_SUCCESS;
+	}
+
+	if (IsRegKey(hKey, enLocalizeKey)) {
+		if (_stricmp(lpValueName, "Language") == 0) {
+			GetIniOutString("Localize", lpValueName, "USA", lpData, lpcbData);
+		}
+		return ERROR_SUCCESS;
+	}
+
+	if (IsRegKey(hKey, enSCURKKey)) {
+		if (_stricmp(lpValueName, "CycleColors") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 1, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "GridHeight") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 2, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "GridWidth") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 2, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "ShowClipRegion") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 0, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "ShowDrawGrid") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 0, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "SnapToGrid") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 0, lpData, lpcbData);
+		}
+		else if (_stricmp(lpValueName, "Sound") == 0) {
+			GetIniOutDWORD("SCURK", lpValueName, 1, lpData, lpcbData);
+		}
+		return ERROR_SUCCESS;
+	}
+
+	if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> RegQueryValueExA(0x%08x, %s, 0x%08X, 0x%08X, 0x%08X, 0x%08X)\n", _ReturnAddress(), hKey, lpValueName,
+			lpReserved, *lpType, lpData, lpcbData);
+
+	return RegQueryValueExA(hKey, lpValueName, lpReserved, lpType, lpData, lpcbData);
+}
+
+extern "C" LSTATUS __stdcall Hook_RegCreateKeyExA(HKEY hKey, LPCSTR lpSubKey, DWORD Reserved, LPSTR lpClass, DWORD dwOptions, REGSAM samDesired,
+	const LPSECURITY_ATTRIBUTES lpSecurityAttributes, PHKEY phkResult, LPDWORD lpdwDisposition) {
+
+	unsigned long ulKey;
+
+	ulKey = 0;
+	if (RegLookup(lpSubKey, &ulKey)) {
+		*phkResult = (HKEY)(REG_KEY_BASE + ulKey);
+		return ERROR_SUCCESS;
+	}
+
+	if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> RegCreateKeyExA(0x%08x, %s, ...)\n", _ReturnAddress(), hKey, lpSubKey);
+
+	return RegCreateKeyExA(hKey, lpSubKey, Reserved, lpClass, dwOptions, samDesired, lpSecurityAttributes, phkResult, lpdwDisposition);
+}
+
+extern "C" LSTATUS __stdcall Hook_RegCloseKey(HKEY hKey) {
+
+	if (IsFakeRegKey((unsigned long)hKey)) {
+		return ERROR_SUCCESS;
+	}
+
+	if (mischook_debug & MISCHOOK_DEBUG_REGISTRY)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> RegCloseKey(0x%08x)\n", _ReturnAddress(), hKey);
+
+	return RegCloseKey(hKey);
+}
+
+extern "C" HANDLE __stdcall Hook_CreateFileA(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode,
+	LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile) {
+	if (mischook_debug & MISCHOOK_DEBUG_PATHING)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> CreateFileA(%s, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X)\n", _ReturnAddress(), lpFileName,
+			dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+	if (bSettingsUseLocalMovies) {
+		if (iRegPathHookMode == 0) {
+			if ((DWORD)_ReturnAddress() == 0x4A8A90 ||
+				(DWORD)_ReturnAddress() == 0x48A810) {
+				char buf[MAX_PATH + 1];
+
+				memset(buf, 0, sizeof(buf));
+
+				HANDLE hFileHandle = CreateFileA(AdjustSource(buf, lpFileName), dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+				if (mischook_debug & MISCHOOK_DEBUG_PATHING)
+					ConsoleLog(LOG_DEBUG, "MISC: (Modification): 0x%08X -> CreateFileA(%s, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X, 0x%08X) (0x%08x)\n", _ReturnAddress(), lpFileName,
+						dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile, hFileHandle);
+				return hFileHandle;
+			}
+		}
+	}
+	return CreateFileA(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+}
+
+extern "C" HANDLE __stdcall Hook_FindFirstFileA(LPCSTR lpFileName, LPWIN32_FIND_DATAA lpFindFileData) {
+	if (mischook_debug & MISCHOOK_DEBUG_PATHING)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> FindFirstFileA(%s, 0x%08X)\n", _ReturnAddress(), lpFileName, lpFindFileData);
+	if (bSettingsUseLocalMovies) {
+		if (iRegPathHookMode == 0) {
+			if ((DWORD)_ReturnAddress() == 0x4A8A90 ||
+				(DWORD)_ReturnAddress() == 0x48A810) {
+				char buf[MAX_PATH + 1];
+
+				memset(buf, 0, sizeof(buf));
+
+				HANDLE hFileHandle = FindFirstFileA(AdjustSource(buf, lpFileName), lpFindFileData);
+				if (mischook_debug & MISCHOOK_DEBUG_PATHING)
+					ConsoleLog(LOG_DEBUG, "MISC: (Modification): 0x%08X -> FindFirstFileA(%s, 0x%08X) (0x%08x)\n", _ReturnAddress(), buf, lpFindFileData, hFileHandle);
+				return hFileHandle;
+			}
+		}
+	}
+	return FindFirstFileA(lpFileName, lpFindFileData);
+}
+
+void InstallRegistryPathingHooks_SC2K1996(void) {
+	iRegPathHookMode = 0;
+
+	// Install RegSetValueExA hook
+	*(DWORD*)(0X4EF7F8) = (DWORD)Hook_RegSetValueExA;
+
+	// Install RegQueryValueExA hook
+	*(DWORD*)(0x4EF800) = (DWORD)Hook_RegQueryValueExA;
+
+	// Install RegCreateKeyExA hook
+	*(DWORD*)(0x4EF80C) = (DWORD)Hook_RegCreateKeyExA;
+
+	// Install RegCloseKey hook
+	*(DWORD*)(0x4EF810) = (DWORD)Hook_RegCloseKey;
+
+	// Install CreateFileA hook
+	*(DWORD*)(0x4EFADC) = (DWORD)Hook_CreateFileA;
+
+	// Install FindFirstFileA hook
+	*(DWORD*)(0x4EFB8C) = (DWORD)Hook_FindFirstFileA;
+}
+
+void InstallRegistryPathingHooks_SC2K1995(void) {
+	iRegPathHookMode = 1;
+
+	// Install RegSetValueExA hook
+	*(DWORD*)(0X4EE7A8) = (DWORD)Hook_RegSetValueExA;
+
+	// Install RegQueryValueExA hook
+	*(DWORD*)(0x4EE7A4) = (DWORD)Hook_RegQueryValueExA;
+
+	// Install RegCreateKeyExA hook
+	*(DWORD*)(0x4EE7A0) = (DWORD)Hook_RegCreateKeyExA;
+
+	// Install RegCloseKey hook
+	*(DWORD*)(0x4EE7AC) = (DWORD)Hook_RegCloseKey;
+}
+
+void InstallRegistryPathingHooks_SCURK1996(void) {
+	iRegPathHookMode = 2;
+
+	// Install RegSetValueExA hook
+	*(DWORD*)(0X4B05F0) = (DWORD)Hook_RegSetValueExA;
+
+	// Install RegQueryValueExA hook
+	*(DWORD*)(0x4B05E4) = (DWORD)Hook_RegQueryValueExA;
+
+	// Install RegCreateKeyExA hook
+	*(DWORD*)(0x4B05E8) = (DWORD)Hook_RegCreateKeyExA;
+
+	// Install RegCloseKey hook
+	*(DWORD*)(0x4B05EC) = (DWORD)Hook_RegCloseKey;
+}

--- a/modules/scurkfix.cpp
+++ b/modules/scurkfix.cpp
@@ -45,6 +45,9 @@ BOOL InjectSCURKFix(void) {
 		return TRUE;
 	}
 
+	if (dwSCURKAppVersion == SC2KVERSION_1996)
+		InstallRegistryPathingHooks_SCURK1996();
+
 	// Tell the rest of the plugin we're in SCURK
 	bInSCURK = TRUE;
 	// return TRUE; 

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -21,10 +21,6 @@ char szGamePath[MAX_PATH];
 char szSettingsMayorName[64];
 char szSettingsCompanyName[64];
 
-#if STORE_DRIVE_LETTER
-char szSettingsMovieDriveLetter[4];
-#endif
-
 BOOL bSettingsMusicInBackground = TRUE;
 BOOL bSettingsUseSoundReplacements = TRUE;
 BOOL bSettingsShuffleMusic = FALSE;
@@ -51,59 +47,6 @@ void SetGamePath(void) {
 	PathRemoveFileSpecA(szModulePathName);
 	strcpy_s(szGamePath, MAX_PATH, szModulePathName);
 }
-
-#if STORE_DRIVE_LETTER
-std::vector<char *> DriveLetters;
-
-static bool SetDefaultDriveLetterAndPath(void) {
-	szSettingsMovieDriveLetter[0] = szGamePath[0];
-	return true;
-}
-
-bool FillDriveSelectionArray(void) {
-	char szLDrivesBuf[128 + 1];
-
-	memset(szLDrivesBuf, 0, sizeof(szLDrivesBuf));
-
-	DriveLetters.clear();
-
-	// Set a viable default.
-	if (!SetDefaultDriveLetterAndPath())
-		return false;
-
-	DWORD dwLDRet = GetLogicalDriveStringsA(sizeof(szLDrivesBuf)-1, szLDrivesBuf);
-	if (dwLDRet > 0 && dwLDRet <= sizeof(szLDrivesBuf)-1) {
-		char *szLDriveEnt = szLDrivesBuf;
-		while (*szLDriveEnt) {
-			char szLDriveBuf[4];
-
-			memset(szLDriveBuf, 0, sizeof(szLDriveBuf));
-
-			if (!isalpha(szLDriveEnt[0]))
-				break;
-
-			szLDriveBuf[0] = szLDriveEnt[0];
-
-			DriveLetters.push_back(_strdup(szLDriveBuf));
-
-			szLDriveEnt += strlen(szLDriveEnt) + 1;
-		}
-	}
-	else {
-		DriveLetters.push_back(_strdup(szSettingsMovieDriveLetter));
-	}
-
-	return true;
-}
-
-void FreeDriveSelectionArray(void) {
-	for (unsigned i = 0; i < DriveLetters.size(); i++)
-		if (DriveLetters[i])
-			free(DriveLetters[i]);
-
-	DriveLetters.clear();
-}
-#endif
 
 const char *GetIniPath() {
 	static char szIniPath[MAX_PATH];
@@ -169,15 +112,6 @@ void LoadSettings(void) {
 	bSettingsUseNewStrings = GetPrivateProfileIntA(section, "bSettingsUseNewStrings", bSettingsUseNewStrings, ini_file);
 	bSettingsUseLocalMovies = GetPrivateProfileIntA(section, "bSettingsUseLocalMovies", bSettingsUseLocalMovies, ini_file);
 	bSettingsAlwaysSkipIntro = GetPrivateProfileIntA(section, "bSettingsAlwaysSkipIntro", bSettingsAlwaysSkipIntro, ini_file);
-#if STORE_DRIVE_LETTER
-	char szTempDriveLetter[4];
-
-	memset(szTempDriveLetter, 0, sizeof(szTempDriveLetter));
-
-	szTempDriveLetter[0] = szGamePath[0];
-
-	GetPrivateProfileStringA(section, "szSettingsMovieDriveLetter", szTempDriveLetter, szSettingsMovieDriveLetter, sizeof(szSettingsMovieDriveLetter)-1, ini_file);
-#endif
 
 	// Gameplay modifications
 
@@ -217,9 +151,6 @@ void SaveSettings(BOOL onload) {
 	WritePrivateProfileIntA(section, "bSettingsUseNewStrings", bSettingsUseNewStrings, ini_file);
 	WritePrivateProfileIntA(section, "bSettingsUseLocalMovies", bSettingsUseLocalMovies, ini_file);
 	WritePrivateProfileIntA(section, "bSettingsAlwaysSkipIntro", bSettingsAlwaysSkipIntro, ini_file);
-#if STORE_DRIVE_LETTER
-	WritePrivateProfileStringA(section, "szSettingsMovieDriveLetter", szSettingsMovieDriveLetter, ini_file);
-#endif
 
 	// Gameplay modifications
 

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -6,6 +6,7 @@
 #include <windowsx.h>
 #include <psapi.h>
 #include <commctrl.h>
+#include <shlwapi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
@@ -15,10 +16,14 @@
 
 static DWORD dwDummy;
 
+char szGamePath[MAX_PATH];
+
 char szSettingsMayorName[64];
 char szSettingsCompanyName[64];
 
+#if STORE_DRIVE_LETTER
 char szSettingsMovieDriveLetter[4];
+#endif
 
 BOOL bSettingsMusicInBackground = TRUE;
 BOOL bSettingsUseSoundReplacements = TRUE;
@@ -39,18 +44,19 @@ BOOL bSettingsAlwaysSkipIntro = FALSE;
 BOOL bSettingsMilitaryBaseRevenue = FALSE;	// NYI
 BOOL bSettingsFixOrdinances = FALSE;		// NYI
 
+void SetGamePath(void) {
+	char szModulePathName[MAX_PATH];
+	GetModuleFileNameEx(GetCurrentProcess(), NULL, szModulePathName, MAX_PATH);
+
+	PathRemoveFileSpecA(szModulePathName);
+	strcpy_s(szGamePath, MAX_PATH, szModulePathName);
+}
+
+#if STORE_DRIVE_LETTER
 std::vector<char *> DriveLetters;
 
-static bool SetDefaultDriveLetter(void) {
-	memset(szSettingsMovieDriveLetter, 0, sizeof(szSettingsMovieDriveLetter));
-
-	char szModuleFileName[MAX_PATH];
-	GetModuleFileNameEx(GetCurrentProcess(), NULL, szModuleFileName, MAX_PATH);
-
-	if (!isalpha(szModuleFileName[0]))
-		return false;
-
-	szSettingsMovieDriveLetter[0] = szModuleFileName[0];
+static bool SetDefaultDriveLetterAndPath(void) {
+	szSettingsMovieDriveLetter[0] = szGamePath[0];
 	return true;
 }
 
@@ -62,7 +68,7 @@ bool FillDriveSelectionArray(void) {
 	DriveLetters.clear();
 
 	// Set a viable default.
-	if (!SetDefaultDriveLetter())
+	if (!SetDefaultDriveLetterAndPath())
 		return false;
 
 	DWORD dwLDRet = GetLogicalDriveStringsA(sizeof(szLDrivesBuf)-1, szLDrivesBuf);
@@ -97,185 +103,135 @@ void FreeDriveSelectionArray(void) {
 
 	DriveLetters.clear();
 }
+#endif
+
+const char *GetIniPath() {
+	static char szIniPath[MAX_PATH];
+
+	sprintf_s(szIniPath, MAX_PATH, "%s\\%s", szGamePath, SC2KFIX_INIFILE);
+	return szIniPath;
+}
+
+static void MigrateSC2KFixSettings(void) {
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsMusicInBackground", &bSettingsMusicInBackground);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseSoundReplacements", &bSettingsUseSoundReplacements);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsShuffleMusic", &bSettingsShuffleMusic);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseMultithreadedMusic", &bSettingsUseMultithreadedMusic);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsFrequentCityRefresh", &bSettingsFrequentCityRefresh);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseMP3Music", &bSettingsUseMP3Music);
+
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsAlwaysConsole", &bSettingsAlwaysConsole);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsCheckForUpdates", &bSettingsCheckForUpdates);
+
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseStatusDialog", &bSettingsUseStatusDialog);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsTitleCalendar", &bSettingsTitleCalendar);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseNewStrings", &bSettingsUseNewStrings);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseLocalMovies", &bSettingsUseLocalMovies);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsAlwaysSkipIntro", &bSettingsAlwaysSkipIntro);
+
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsMilitaryBaseRevenue", &bSettingsMilitaryBaseRevenue);
+	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsFixOrdinances", &bSettingsFixOrdinances);
+}
 
 void LoadSettings(void) {
-	HKEY hkeySC2KRegistration;
-	LSTATUS lResultRegistration = RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Registration", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KRegistration, NULL);
-	if (lResultRegistration != ERROR_SUCCESS) {
-		MessageBox(NULL, "Couldn't open registry keys for editing", "sc2kfix error", MB_OK | MB_ICONEXCLAMATION);
-		ConsoleLog(LOG_ERROR, "CORE: Couldn't open registry keys for settings load, error = 0x%08X\n", lResultRegistration);
-		return;
+	const char *ini_file = GetIniPath();
+	const char *section = "Registration";
+	GetPrivateProfileStringA(section, "Mayor Name", "", szSettingsMayorName, sizeof(szSettingsMayorName)-1, ini_file);
+	GetPrivateProfileStringA(section, "Company Name", "", szSettingsCompanyName, sizeof(szSettingsCompanyName)-1, ini_file);
+
+	section = "sc2kfix";
+	char szSectionBuf[32];
+
+	// Check for the section presence.
+	if (!GetPrivateProfileSectionA(section, szSectionBuf, sizeof(szSectionBuf) - 1, ini_file)) {
+		// Check to see whether the values existed in the registry so they can be migrated.
+		MigrateSC2KFixSettings();
 	}
-
-	DWORD dwMayorNameSize = 64;
-	DWORD dwCompanyNameSize = 64;
-	LSTATUS retval = ERROR_SUCCESS;
-
-	retval = RegGetValue(hkeySC2KRegistration, NULL, "Mayor Name", RRF_RT_REG_SZ, NULL, szSettingsMayorName, &dwMayorNameSize);
-	switch (retval) {
-	case ERROR_SUCCESS:
-		break;
-	default:
-		strcpy_s(szSettingsMayorName, "Marvin Maxis");
-		char* buf;
-		FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, retval, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
-		ConsoleLog(LOG_WARNING, "CORE: Error %s loading mayor name; resetting to default.\n", buf);
-		break;
-	}
-
-	retval = RegGetValue(hkeySC2KRegistration, NULL, "Company Name", RRF_RT_REG_SZ, NULL, szSettingsCompanyName, &dwCompanyNameSize);
-	switch (retval) {
-	case ERROR_SUCCESS:
-		break;
-	default:
-		strcpy_s(szSettingsCompanyName, "Q37 Space Modulator Mfg.");
-		char* buf;
-		FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, retval, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0, NULL);
-		ConsoleLog(LOG_WARNING, "CORE: Error %s loading company name; resetting to default.\n", buf);
-		break;
-	}
-
-	HKEY hkeySC2KFix;
-	RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KFix, NULL);
 
 	// QoL/performance settings
 
-	DWORD dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsMusicInBackground", RRF_RT_REG_DWORD, NULL, &bSettingsMusicInBackground, &dwSizeofBool) != ERROR_SUCCESS) {
-		bSettingsMusicInBackground = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsMusicInBackground", NULL, REG_DWORD, (BYTE*)&bSettingsMusicInBackground, sizeof(BOOL));
-	}
+	bSettingsMusicInBackground = GetPrivateProfileIntA(section, "bSettingsMusicInBackground", bSettingsMusicInBackground, ini_file);
+	bSettingsUseSoundReplacements = GetPrivateProfileIntA(section, "bSettingsUseSoundReplacements", bSettingsUseSoundReplacements, ini_file);
+	bSettingsShuffleMusic = GetPrivateProfileIntA(section, "bSettingsShuffleMusic", bSettingsShuffleMusic, ini_file);
+	bSettingsUseMultithreadedMusic = GetPrivateProfileIntA(section, "bSettingsUseMultithreadedMusic", bSettingsUseMultithreadedMusic, ini_file);
+	bSettingsFrequentCityRefresh = GetPrivateProfileIntA(section, "bSettingsFrequentCityRefresh", bSettingsFrequentCityRefresh, ini_file);
+	bSettingsUseMP3Music = GetPrivateProfileIntA(section, "bSettingsUseMP3Music", bSettingsUseMP3Music, ini_file);
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsUseSoundReplacements", RRF_RT_REG_DWORD, NULL, &bSettingsUseSoundReplacements, &dwSizeofBool)) {
-		bSettingsUseSoundReplacements = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsUseSoundReplacements", NULL, REG_DWORD, (BYTE*)&bSettingsUseSoundReplacements, sizeof(BOOL));
-	}
+	// Internal settings
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsShuffleMusic", RRF_RT_REG_DWORD, NULL, &bSettingsShuffleMusic, &dwSizeofBool)) {
-		bSettingsShuffleMusic = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsShuffleMusic", NULL, REG_DWORD, (BYTE*)&bSettingsShuffleMusic, sizeof(BOOL));
-	}
-
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsUseMultithreadedMusic", RRF_RT_REG_DWORD, NULL, &bSettingsUseMultithreadedMusic, &dwSizeofBool)) {
-		bSettingsUseMultithreadedMusic = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsUseMultithreadedMusic", NULL, REG_DWORD, (BYTE*)&bSettingsUseMultithreadedMusic, sizeof(BOOL));
-	}
-
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsFrequentCityRefresh", RRF_RT_REG_DWORD, NULL, &bSettingsFrequentCityRefresh, &dwSizeofBool)) {
-		bSettingsFrequentCityRefresh = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsFrequentCityRefresh", NULL, REG_DWORD, (BYTE*)&bSettingsFrequentCityRefresh, sizeof(BOOL));
-	}
-
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsUseMP3Music", RRF_RT_REG_DWORD, NULL, &bSettingsUseMP3Music, &dwSizeofBool)) {
-		bSettingsUseMP3Music = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsUseMP3Music", NULL, REG_DWORD, (BYTE*)&bSettingsUseMP3Music, sizeof(BOOL));
-	}
-
-	// sc2kfix settings
-
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsAlwaysConsole", RRF_RT_REG_DWORD, NULL, &bSettingsAlwaysConsole, &dwSizeofBool)) {
-		bSettingsAlwaysConsole = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsAlwaysConsole", NULL, REG_DWORD, (BYTE*)&bSettingsAlwaysConsole, sizeof(BOOL));
-	}
-
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsCheckForUpdates", RRF_RT_REG_DWORD, NULL, &bSettingsCheckForUpdates, &dwSizeofBool)) {
-		bSettingsCheckForUpdates = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsCheckForUpdates", NULL, REG_DWORD, (BYTE*)&bSettingsCheckForUpdates, sizeof(BOOL));
-	}
+	bSettingsAlwaysConsole = GetPrivateProfileIntA(section, "bSettingsAlwaysConsole", bSettingsAlwaysConsole, ini_file);
+	bSettingsCheckForUpdates = GetPrivateProfileIntA(section, "bSettingsCheckForUpdates", bSettingsCheckForUpdates, ini_file);
 
 	// Interface settings
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsUseStatusDialog", RRF_RT_REG_DWORD, NULL, &bSettingsUseStatusDialog, &dwSizeofBool)) {
-		bSettingsUseStatusDialog = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsUseStatusDialog", NULL, REG_DWORD, (BYTE*)&bSettingsUseStatusDialog, sizeof(BOOL));
-	}
+	bSettingsUseStatusDialog = GetPrivateProfileIntA(section, "bSettingsUseStatusDialog", bSettingsUseStatusDialog, ini_file);
+	bSettingsTitleCalendar = GetPrivateProfileIntA(section, "bSettingsTitleCalendar", bSettingsTitleCalendar, ini_file);
+	bSettingsUseNewStrings = GetPrivateProfileIntA(section, "bSettingsUseNewStrings", bSettingsUseNewStrings, ini_file);
+	bSettingsUseLocalMovies = GetPrivateProfileIntA(section, "bSettingsUseLocalMovies", bSettingsUseLocalMovies, ini_file);
+	bSettingsAlwaysSkipIntro = GetPrivateProfileIntA(section, "bSettingsAlwaysSkipIntro", bSettingsAlwaysSkipIntro, ini_file);
+#if STORE_DRIVE_LETTER
+	char szTempDriveLetter[4];
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsTitleCalendar", RRF_RT_REG_DWORD, NULL, &bSettingsTitleCalendar, &dwSizeofBool)) {
-		bSettingsTitleCalendar = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsTitleCalendar", NULL, REG_DWORD, (BYTE*)&bSettingsTitleCalendar, sizeof(BOOL));
-	}
+	memset(szTempDriveLetter, 0, sizeof(szTempDriveLetter));
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsUseNewStrings", RRF_RT_REG_DWORD, NULL, &bSettingsUseNewStrings, &dwSizeofBool)) {
-		bSettingsUseNewStrings = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsUseNewStrings", NULL, REG_DWORD, (BYTE*)&bSettingsUseNewStrings, sizeof(BOOL));
-	}
+	szTempDriveLetter[0] = szGamePath[0];
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsUseLocalMovies", RRF_RT_REG_DWORD, NULL, &bSettingsUseLocalMovies, &dwSizeofBool)) {
-		bSettingsUseLocalMovies = TRUE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsUseLocalMovies", NULL, REG_DWORD, (BYTE*)&bSettingsUseLocalMovies, sizeof(BOOL));
-	}
+	GetPrivateProfileStringA(section, "szSettingsMovieDriveLetter", szTempDriveLetter, szSettingsMovieDriveLetter, sizeof(szSettingsMovieDriveLetter)-1, ini_file);
+#endif
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsAlwaysSkipIntro", RRF_RT_REG_DWORD, NULL, &bSettingsAlwaysSkipIntro, &dwSizeofBool)) {
-		bSettingsAlwaysSkipIntro = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsAlwaysSkipIntro", NULL, REG_DWORD, (BYTE*)&bSettingsAlwaysSkipIntro, sizeof(BOOL));
-	}
+	// Gameplay modifications
 
-	// Gameplay mods
+	bSettingsMilitaryBaseRevenue = GetPrivateProfileIntA(section, "bSettingsMilitaryBaseRevenue", bSettingsMilitaryBaseRevenue, ini_file);
+	bSettingsFixOrdinances = GetPrivateProfileIntA(section, "bSettingsFixOrdinances", bSettingsFixOrdinances, ini_file);
 
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsMilitaryBaseRevenue", RRF_RT_REG_DWORD, NULL, &bSettingsMilitaryBaseRevenue, &dwSizeofBool)) {
-		bSettingsMilitaryBaseRevenue = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsMilitaryBaseRevenue", NULL, REG_DWORD, (BYTE*)&bSettingsMilitaryBaseRevenue, sizeof(BOOL));
-	}
-
-	dwSizeofBool = sizeof(BOOL);
-	if (RegGetValue(hkeySC2KFix, NULL, "bSettingsFixOrdinances", RRF_RT_REG_DWORD, NULL, &bSettingsFixOrdinances, &dwSizeofBool)) {
-		bSettingsFixOrdinances = FALSE;
-		RegSetValueEx(hkeySC2KFix, "bSettingsFixOrdinances", NULL, REG_DWORD, (BYTE*)&bSettingsFixOrdinances, sizeof(BOOL));
-	}
+	SaveSettings(TRUE);
 }
 
-void SaveSettings(void) {
-	HKEY hkeySC2KRegistration;
-	LSTATUS lResultRegistration = RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\Registration", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KRegistration, NULL);
-	if (lResultRegistration != ERROR_SUCCESS) {
-		MessageBox(NULL, "Couldn't open registry keys for editing", "sc2kfix error", MB_OK | MB_ICONEXCLAMATION);
-		ConsoleLog(LOG_ERROR, "CORE: Couldn't open registry keys for registry check, error = 0x%08X\n", lResultRegistration);
-		return;
-	}
+void SaveSettings(BOOL onload) {
+	const char *ini_file = GetIniPath();
+	const char *section = "Registration";
 
-	// Write registration strings
-	RegSetValueEx(hkeySC2KRegistration, "Mayor Name", NULL, REG_SZ, (BYTE*)szSettingsMayorName, strlen(szSettingsMayorName) + 1);
-	RegSetValueEx(hkeySC2KRegistration, "Company Name", NULL, REG_SZ, (BYTE*)szSettingsCompanyName, strlen(szSettingsCompanyName) + 1);
+	WritePrivateProfileStringA(section, "Mayor Name", szSettingsMayorName, ini_file);
+	WritePrivateProfileStringA(section, "Company Name", szSettingsCompanyName, ini_file);
 
-	HKEY hkeySC2KFix;
-	RegCreateKeyEx(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", NULL, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hkeySC2KFix, NULL);
+	section = "sc2kfix";
 
-	// Write sc2kfix settings
-	RegSetValueEx(hkeySC2KFix, "bSettingsMusicInBackground", NULL, REG_DWORD, (BYTE*)&bSettingsMusicInBackground, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsUseSoundReplacements", NULL, REG_DWORD, (BYTE*)&bSettingsUseSoundReplacements, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsShuffleMusic", NULL, REG_DWORD, (BYTE*)&bSettingsShuffleMusic, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsUseMultithreadedMusic", NULL, REG_DWORD, (BYTE*)&bSettingsUseMultithreadedMusic, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsFrequentCityRefresh", NULL, REG_DWORD, (BYTE*)&bSettingsFrequentCityRefresh, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsUseMP3Music", NULL, REG_DWORD, (BYTE*)&bSettingsUseMP3Music, sizeof(BOOL));
+	// QoL/performance settings
 
-	RegSetValueEx(hkeySC2KFix, "bSettingsAlwaysConsole", NULL, REG_DWORD, (BYTE*)&bSettingsAlwaysConsole, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsCheckForUpdates", NULL, REG_DWORD, (BYTE*)&bSettingsCheckForUpdates, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "bSettingsMusicInBackground", bSettingsMusicInBackground, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsUseSoundReplacements", bSettingsUseSoundReplacements, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsShuffleMusic", bSettingsShuffleMusic, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsUseMultithreadedMusic", bSettingsUseMultithreadedMusic, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsFrequentCityRefresh", bSettingsFrequentCityRefresh, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsUseMP3Music", bSettingsUseMP3Music, ini_file);
 
-	RegSetValueEx(hkeySC2KFix, "bSettingsUseStatusDialog", NULL, REG_DWORD, (BYTE*)&bSettingsUseStatusDialog, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsTitleCalendar", NULL, REG_DWORD, (BYTE*)&bSettingsTitleCalendar, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsUseNewStrings", NULL, REG_DWORD, (BYTE*)&bSettingsUseNewStrings, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsUseLocalMovies", NULL, REG_DWORD, (BYTE*)&bSettingsUseLocalMovies, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsAlwaysSkipIntro", NULL, REG_DWORD, (BYTE*)&bSettingsAlwaysSkipIntro, sizeof(BOOL));
+	// Internal settings
 
-	RegSetValueEx(hkeySC2KFix, "bSettingsMilitaryBaseRevenue", NULL, REG_DWORD, (BYTE*)&bSettingsMilitaryBaseRevenue, sizeof(BOOL));
-	RegSetValueEx(hkeySC2KFix, "bSettingsFixOrdinances", NULL, REG_DWORD, (BYTE*)&bSettingsFixOrdinances, sizeof(BOOL));
+	WritePrivateProfileIntA(section, "bSettingsAlwaysConsole", bSettingsAlwaysConsole, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsCheckForUpdates", bSettingsCheckForUpdates, ini_file);
+
+	// Interface settings
+
+	WritePrivateProfileIntA(section, "bSettingsUseStatusDialog", bSettingsUseStatusDialog, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsTitleCalendar", bSettingsTitleCalendar, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsUseNewStrings", bSettingsUseNewStrings, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsUseLocalMovies", bSettingsUseLocalMovies, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsAlwaysSkipIntro", bSettingsAlwaysSkipIntro, ini_file);
+#if STORE_DRIVE_LETTER
+	WritePrivateProfileStringA(section, "szSettingsMovieDriveLetter", szSettingsMovieDriveLetter, ini_file);
+#endif
+
+	// Gameplay modifications
+
+	WritePrivateProfileIntA(section, "bSettingsMilitaryBaseRevenue", bSettingsMilitaryBaseRevenue, ini_file);
+	WritePrivateProfileIntA(section, "bSettingsFixOrdinances", bSettingsFixOrdinances, ini_file);
+
 	ConsoleLog(LOG_INFO, "CORE: Saved sc2kfix settings.\n");
 
-	// Update any hooks we need to.
-	UpdateMiscHooks();
+	if (!onload) {
+		// Update any hooks we need to.
+		UpdateMiscHooks();
+	}
 }
 
 static void SetSettingsTabOrdering(HWND hwndDlg) {
@@ -479,7 +435,7 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			bSettingsFixOrdinances = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_FIX_ORDINANCES));
 
 			// Save the settings
-			SaveSettings();
+			SaveSettings(FALSE);
 			EndDialog(hwndDlg, wParam);
 			break;
 		case ID_SETTINGS_CANCEL:

--- a/modules/settings.cpp
+++ b/modules/settings.cpp
@@ -34,7 +34,6 @@ BOOL bSettingsCheckForUpdates = TRUE;
 BOOL bSettingsUseStatusDialog = FALSE;
 BOOL bSettingsTitleCalendar = TRUE;
 BOOL bSettingsUseNewStrings = TRUE;
-BOOL bSettingsUseLocalMovies = TRUE;
 BOOL bSettingsAlwaysSkipIntro = FALSE;
 
 BOOL bSettingsMilitaryBaseRevenue = FALSE;	// NYI
@@ -69,7 +68,6 @@ static void MigrateSC2KFixSettings(void) {
 	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseStatusDialog", &bSettingsUseStatusDialog);
 	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsTitleCalendar", &bSettingsTitleCalendar);
 	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseNewStrings", &bSettingsUseNewStrings);
-	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsUseLocalMovies", &bSettingsUseLocalMovies);
 	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsAlwaysSkipIntro", &bSettingsAlwaysSkipIntro);
 
 	MigrateRegBOOLValue(HKEY_CURRENT_USER, "Software\\Maxis\\SimCity 2000\\sc2kfix", "bSettingsMilitaryBaseRevenue", &bSettingsMilitaryBaseRevenue);
@@ -110,7 +108,6 @@ void LoadSettings(void) {
 	bSettingsUseStatusDialog = GetPrivateProfileIntA(section, "bSettingsUseStatusDialog", bSettingsUseStatusDialog, ini_file);
 	bSettingsTitleCalendar = GetPrivateProfileIntA(section, "bSettingsTitleCalendar", bSettingsTitleCalendar, ini_file);
 	bSettingsUseNewStrings = GetPrivateProfileIntA(section, "bSettingsUseNewStrings", bSettingsUseNewStrings, ini_file);
-	bSettingsUseLocalMovies = GetPrivateProfileIntA(section, "bSettingsUseLocalMovies", bSettingsUseLocalMovies, ini_file);
 	bSettingsAlwaysSkipIntro = GetPrivateProfileIntA(section, "bSettingsAlwaysSkipIntro", bSettingsAlwaysSkipIntro, ini_file);
 
 	// Gameplay modifications
@@ -149,7 +146,6 @@ void SaveSettings(BOOL onload) {
 	WritePrivateProfileIntA(section, "bSettingsUseStatusDialog", bSettingsUseStatusDialog, ini_file);
 	WritePrivateProfileIntA(section, "bSettingsTitleCalendar", bSettingsTitleCalendar, ini_file);
 	WritePrivateProfileIntA(section, "bSettingsUseNewStrings", bSettingsUseNewStrings, ini_file);
-	WritePrivateProfileIntA(section, "bSettingsUseLocalMovies", bSettingsUseLocalMovies, ini_file);
 	WritePrivateProfileIntA(section, "bSettingsAlwaysSkipIntro", bSettingsAlwaysSkipIntro, ini_file);
 
 	// Gameplay modifications
@@ -184,7 +180,6 @@ static void SetSettingsTabOrdering(HWND hwndDlg) {
 
 	// Interface Settings
 	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), NULL, 0, 0, 0, 0, uFlags);
-	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), NULL, 0, 0, 0, 0, uFlags);
 	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), NULL, 0, 0, 0, 0, uFlags);
 	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), NULL, 0, 0, 0, 0, uFlags);
 	SetWindowPos(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG), NULL, 0, 0, 0, 0, uFlags);
@@ -265,8 +260,6 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			"By default the title bar only displays the month and year. Enabling this setting will display the full in-game date instead.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS),
 			"Certain strings in the game have typos, grammatical issues, and/or ambiguous wording. This setting loads corrected strings in memory in place of the affected originals.");
-		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES),
-			"Enabling this setting will play the introduction \"in-flight movie\" and the WillTV interview videos from the MOVIES directory, if the video files have been copied there from the install CD.");
 		CreateTooltip(hwndDlg, GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO),
 			"Once enabled the introduction videos will be skipped on startup (This will only apply if the videos have been detected, otherwise the standard warning will be displayed).");
 
@@ -327,7 +320,6 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG), bSettingsUseStatusDialog ? BST_CHECKED : BST_UNCHECKED);
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), bSettingsTitleCalendar ? BST_CHECKED : BST_UNCHECKED);
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), bSettingsUseNewStrings ? BST_CHECKED : BST_UNCHECKED);
-		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), bSettingsUseLocalMovies ? BST_CHECKED : BST_UNCHECKED);
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), bSettingsAlwaysSkipIntro ? BST_CHECKED : BST_UNCHECKED);
 
 		Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), bSettingsMilitaryBaseRevenue ? BST_CHECKED : BST_UNCHECKED);
@@ -359,7 +351,6 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			bSettingsUseStatusDialog = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG));
 			bSettingsTitleCalendar = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE));
 			bSettingsUseNewStrings = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS));
-			bSettingsUseLocalMovies = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES));
 			bSettingsAlwaysSkipIntro = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO));
 
 			bSettingsMilitaryBaseRevenue = Button_GetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE));
@@ -387,7 +378,6 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), BST_CHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), BST_CHECKED);
-			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), BST_CHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), BST_UNCHECKED);
 
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), BST_UNCHECKED);
@@ -408,7 +398,6 @@ BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPAR
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_STATUS_DIALOG), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_TITLE_DATE), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_NEW_STRINGS), BST_UNCHECKED);
-			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_LOCAL_MOVIES), BST_UNCHECKED);
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_SKIP_INTRO), BST_UNCHECKED);
 
 			Button_SetCheck(GetDlgItem(hwndDlg, IDC_SETTINGS_CHECK_MILITARY_REVENUE), BST_UNCHECKED);

--- a/resource.h
+++ b/resource.h
@@ -41,11 +41,10 @@
 #define IDC_STATIC_TILERENDER           21028
 #define IDC_STATIC_SIMSTAT_BGD          21029
 #define IDC_STATIC_VERSIONINFO          21031
-#define IDC_SETTINGS_CHECK_LOCAL_MOVIES 21032
-#define IDC_SETTINGS_CHECK_MP3_MUSIC    21033
-#define IDC_SETTINGS_CHECK_SKIP_INTRO   21034
-#define IDC_STATIC_COMPASS              21035
-#define IDC_BUTTON_GOTO                 21036
+#define IDC_SETTINGS_CHECK_MP3_MUSIC    21032
+#define IDC_SETTINGS_CHECK_SKIP_INTRO   21033
+#define IDC_STATIC_COMPASS              21034
+#define IDC_BUTTON_GOTO                 21035
 #define IDR_WAVE_500                    23001
 #define IDR_WAVE_514                    23002
 #define IDR_WAVE_529                    23003
@@ -75,7 +74,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        23040
 #define _APS_NEXT_COMMAND_VALUE         40002
-#define _APS_NEXT_CONTROL_VALUE         21037
+#define _APS_NEXT_CONTROL_VALUE         21036
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/sc2kfix.rc
+++ b/sc2kfix.rc
@@ -129,11 +129,11 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,35,247,10
     CONTROL         " *Always start the sc2kfix console on game startup (Default: off)",IDC_SETTINGS_CHECK_CONSOLE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,205,247,10
-    GROUPBOX        "Gameplay Mod Settings",IDC_STATIC,277,115,261,119
+    GROUPBOX        "Gameplay Mod Settings",IDC_STATIC,277,101,261,119
     CONTROL         " *Military bases generate revenue (Default: off)",IDC_SETTINGS_CHECK_MILITARY_REVENUE,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,128,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,114,247,10
     CONTROL         " *Fully restore partially-implemented ordinances (Default: off)",IDC_SETTINGS_CHECK_FIX_ORDINANCES,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,156,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,142,247,10
     CONTROL         " *Check for sc2kfix updates on game startup (Default: on)",IDC_SETTINGS_CHECK_CHECK_FOR_UPDATES,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,219,247,10
     PUSHBUTTON      "Defaults",ID_SETTINGS_DEFAULTS,293,252,50,14
@@ -141,22 +141,20 @@ BEGIN
     RTEXT           "sc2kfix version 0.0-dev (tag)",IDC_STATIC_VERSIONINFO,420,262,126,8,WS_DISABLED
     CONTROL         " *Use multithreaded music engine (Default: on)",IDC_SETTINGS_CHECK_MULTITHREADED_MUSIC,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,143,247,10
-    GROUPBOX        "Interface Settings",IDC_STATIC,277,23,261,85
+    GROUPBOX        "Interface Settings",IDC_STATIC,277,23,261,71
     CONTROL         " Display full SimCalendar date in title bar (Default: on)",IDC_SETTINGS_CHECK_TITLE_DATE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,49,247,10
     CONTROL         " Display city growth in real-time instead of in batches (Default: on)",IDC_SETTINGS_CHECK_REFRESH_RATE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,157,247,10
     CONTROL         " *Use expanded list of buildings for Army bases (Default: off)",IDC_SETTINGS_CHECK_MILITARY_BUILDINGS,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,142,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,128,247,10
     CONTROL         " *Use rebalanced radioactive decay algorithm (Default: off)",IDC_SETTINGS_CHECK_RADIOACTIVE_DECAY,
-                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,170,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_DISABLED | WS_TABSTOP,284,156,247,10
     GROUPBOX        "sc2kfix Core Settings",IDC_STATIC,7,192,261,42
-    CONTROL         " Use videos inside game's ""MOVIES"" directory (Default: on)",IDC_SETTINGS_CHECK_LOCAL_MOVIES,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,78,247,10
     CONTROL         " Play MP3 music instead of MIDI music if present (Default: off)",IDC_SETTINGS_CHECK_MP3_MUSIC,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,14,171,247,10
     CONTROL         " Always skip introduction videos (Default: off)",IDC_SETTINGS_CHECK_SKIP_INTRO,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,92,247,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,284,78,247,10
 END
 
 103 DIALOGEX 0, 0, 72, 195

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|Win32">
@@ -78,6 +78,7 @@
     <ClCompile Include="hooks\hook_mmtimers.cpp" />
     <ClCompile Include="modules\military.cpp" />
     <ClCompile Include="modules\music.cpp" />
+    <ClCompile Include="modules\registry_pathing.cpp" />
     <ClCompile Include="modules\sc2k_1996.cpp" />
     <ClCompile Include="modules\registry_install.cpp" />
     <ClCompile Include="modules\scurkfix.cpp" />

--- a/sc2kfix.vcxproj.filters
+++ b/sc2kfix.vcxproj.filters
@@ -101,6 +101,9 @@
     <ClCompile Include="modules\military.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="modules\registry_pathing.cpp">
+      <Filter>Source Files\Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="sc2kfix.rc">

--- a/utility.cpp
+++ b/utility.cpp
@@ -145,3 +145,27 @@ BOOL FileExists(const char* name) {
 	}
 	return FALSE;
 }
+
+BOOL WritePrivateProfileIntA(const char *section, const char *name, int value, const char *ini_name) {
+	char szBuf[128 + 1];
+
+	memset(szBuf, 0, sizeof(szBuf));
+
+	sprintf_s(szBuf, sizeof(szBuf) - 1, "%d", value);
+	return WritePrivateProfileStringA(section, name, szBuf, ini_name);
+}
+
+void MigrateRegStringValue(HKEY hKey, const char *lpSubKey, const char *lpValueName, char *szOutBuf, DWORD dwLen) {
+	DWORD dwOutBufLen = dwLen;
+	RegGetValueA(hKey, lpSubKey, lpValueName, RRF_RT_REG_SZ, NULL, szOutBuf, &dwOutBufLen);
+}
+
+void MigrateRegDWORDValue(HKEY hKey, const char *lpSubKey, const char *lpValueName, DWORD *dwOut, DWORD dwSize) {
+	DWORD dwOutSize = dwSize;
+	RegGetValueA(hKey, lpSubKey, lpValueName, RRF_RT_REG_DWORD, NULL, dwOut, &dwOutSize);
+}
+
+void MigrateRegBOOLValue(HKEY hKey, const char *lpSubKey, const char *lpValueName, BOOL *bOut) {
+	DWORD dwOutSize = sizeof(BOOL);
+	RegGetValueA(hKey, lpSubKey, lpValueName, RRF_RT_REG_DWORD, NULL, bOut, &dwOutSize);
+}


### PR DESCRIPTION
I've placed this pull request in "draft" mode for now since there's still one area I'm undecided about, I suppose it depends on whether it matters (the GUI aspects for it haven't been added yet for that reason).

The one area is specifically to do with handling the videos without the local setting being enabled.

The disabled setting is for setting the drive letter (it would then be set onto both the Goodies and original video location).

Aside from that, I can confirm (on this system) that the portability works for SC2K 1996, 1995 and SCURK 1996.