### PR TITLE
Add in two defines for if they're not present by default.

### DIFF
--- a/kuroko/vendor/rline.c
+++ b/kuroko/vendor/rline.c
@@ -37,6 +37,14 @@
 #include "rline.h"
 #endif
 
+#ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
+#define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200
+#endif
+
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
 static int _isdigit(int c) { if (c > 128) return 0; return isdigit(c); }
 static int _isxdigit(int c) { if (c > 128) return 0; return isxdigit(c); }
 


### PR DESCRIPTION
Both of the referenced defines have been added locally for if they're not present by default.

(There is still one case in vs2015 where the build will fail if _CRT_SECURE_NO_WARNINGS isn't set, but that doesn't crop up for vs2022 - it hasn't been included at this time)