### PR TITLE
Exit requester - Cancel operation fully functional

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -220,29 +220,23 @@ extern "C" void __stdcall Hook_ApparentExit(void) {
 	// 0x40A6C8 - This one is hit when you press the close gadget or goto close in the "Main Window" top-level menu. (or if you press Alt + F4)
 	// 0x481EC6 - This one is hit when you goto close in the "Game Window" top-level menu.
 
-	ConsoleLog(LOG_DEBUG, "DBG: 0x%08X -> ApparentExit()\n", _ReturnAddress());
-
-	int ret;
-	int iThat;
+	int iReqRet;
+	int iSource;
 	DWORD dwOldVal1, dwOldVal2;
 
-	int(__stdcall *H_ExitRequester)(int) = (int(__stdcall *)(int))0x40150A;
-	void(__thiscall *H_SaveCity)(void *) = (void(__thiscall *)(void *))0x4015A0;
-	int(__thiscall *H_PreGameMenuDialogToggle)(void *, int) = (int(__thiscall *)(void *, int))0x40103C;
-
-	iThat = *((DWORD *)pThis + 206);
+	iSource = *((DWORD *)pThis + 206);
 	dwOldVal1 = *((DWORD *)pThis + 64);
-	dwOldVal2 = *((DWORD *)pThis + 63); // If this is '1' by default this appears to indicate 'Quit' was clicked from the pre-game toolmenu.
+	dwOldVal2 = *((DWORD *)pThis + 63); // If this is '1' by default this appears to indicate 'Quit' was clicked from the pregame menu dialog.
 
 	// One of the two (or both) suspend the simulation.
 	*((DWORD *)pThis + 64) = 1;
 	*((DWORD *)pThis + 63) = 0;
-	ret = H_ExitRequester(iThat);
-	if (ret != 2) {
-		if (ret == 6) {
-			H_SaveCity((void *)pThis);
+	iReqRet = Game_ExitRequester((void *)pThis, iSource);
+	if (iReqRet != 2) {
+		if (iReqRet == 6) {
+			Game_DoSaveCity((void *)pThis);
 		}
-		H_PreGameMenuDialogToggle(*((void **)pThis + 7), 0);
+		Game_PreGameMenuDialogToggle(*((void **)pThis + 7), 0);
 		Game_CWinApp_OnAppExit((void *)pThis);
 		return;
 	}

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -210,7 +210,7 @@ extern "C" DWORD __cdecl Hook_SmackOpen(LPCSTR lpFileName, uint32_t uFlags, int3
 	return SMKOpenProc(AdjustSource(buf, lpFileName), uFlags, iExBuf);
 }
 
-extern "C" int __stdcall Hook_ApparentExit(void) {
+extern "C" void __stdcall Hook_ApparentExit(void) {
 	DWORD pThis;
 
 	__asm mov[pThis], ecx
@@ -222,9 +222,41 @@ extern "C" int __stdcall Hook_ApparentExit(void) {
 
 	ConsoleLog(LOG_DEBUG, "DBG: 0x%08X -> ApparentExit()\n", _ReturnAddress());
 
-	int(__thiscall *ApparentExit)(void *) = (int(__thiscall *)(void *))0x406680;
+	int ret, ret2;
+	int iThat;
+	DWORD dwOldVal1, dwOldVal2;
 
-	return ApparentExit((void *)pThis);
+	int(__stdcall *H_ExitRequester)(int) = (int(__stdcall *)(int))0x40150A;
+	int(__thiscall *H_ToolMenuDialogToggle)(void *, int) = (int(__thiscall *)(void *, int))0x40103C;
+
+	iThat = *((DWORD *)pThis + 206);
+	dwOldVal1 = *((DWORD *)pThis + 64);
+	dwOldVal2 = *((DWORD *)pThis + 63); // If this is '1' by default this appears to indicate 'Quit' was clicked from the pre-game toolmenu.
+	ConsoleLog(LOG_DEBUG, "DBG: (0x%08X) %d / %d\n", iThat, dwOldVal1, dwOldVal2);
+	// One of the two (or both) suspend the simulation.
+	*((DWORD *)pThis + 64) = 1;
+	*((DWORD *)pThis + 63) = 0;
+	ret = H_ExitRequester(iThat);
+	ConsoleLog(LOG_DEBUG, "DBG: ret: %d\n", ret);
+	if (ret == 6) {
+		ret2 = H_ExitRequester(pThis);
+		ConsoleLog(LOG_DEBUG, "DBG: ret2: %d\n", ret2);
+	GOBACK:
+		H_ToolMenuDialogToggle(*((void **)pThis + 7), 0);
+		Game_CWinApp_OnAppExit((void *)pThis);
+		return;
+	}
+	if (ret != 2) {
+		goto GOBACK;
+	}
+	else {
+		// This case is hit when you click "Cancel", you then want to restore both old values in order
+		// for the simulation to properly resume (based on current tests).
+		*((DWORD *)pThis + 64) = dwOldVal1;
+		*((DWORD *)pThis + 63) = dwOldVal2;
+		return;
+	}
+	*((DWORD*)pThis + 63) = 0;
 }
 
 static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -233,9 +233,8 @@ extern "C" void __stdcall Hook_ApparentExit(void) {
 	*((DWORD *)pThis + 63) = 0;
 	iReqRet = Game_ExitRequester((void *)pThis, iSource);
 	if (iReqRet != 2) {
-		if (iReqRet == 6) {
+		if (iReqRet == 6)
 			Game_DoSaveCity((void *)pThis);
-		}
 		Game_PreGameMenuDialogToggle(*((void **)pThis + 7), 0);
 		Game_CWinApp_OnAppExit((void *)pThis);
 		return;

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -745,10 +745,13 @@ int PlaceRoadsAlongPath(int x1, int y1, int x2, int y2);
 
 // Function pointers
 
+GAMECALL(0x40103C, int, __thiscall, PreGameMenuDialogToggle, void *pThis, int iShow)
 GAMECALL(0x40106E, int, __cdecl, PlaceRoadAtCoordinates, __int16 x, __int16 y)
 GAMECALL(0x401096, int, __thiscall, SoundPlaySound, void* pThis, int iSoundID)
 GAMECALL(0x4011E5, int, __thiscall, MapToolSoundTrigger, void* pThis)
 GAMECALL(0x4014F1, int, __thiscall, TileHighlightUpdate, int pThis)
+GAMECALL(0x40150A, int, __thiscall, ExitRequester, void *pThis, int iSource)
+GAMECALL(0x4015A0, void, __thiscall, DoSaveCity, void *pThis)
 GAMECALL(0x401519, void, __thiscall, ToolMenuEnable, void* pThis)
 GAMECALL(0x4016D1, int, __thiscall, CenterOnNewScreenCoordinates, void *pThis, __int16 iNewScreenPointX, __int16 iNewScreenPointY)
 GAMECALL(0x40178F, __int16, __cdecl, PlaceTileWithMilitaryCheck, __int16 x, __int16 y, __int16 iTileID)

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -785,6 +785,7 @@ GAMECALL(0x480140, void, __stdcall, LoadSoundBuffer, int iSoundID, void* pBuffer
 GAMECALL(0x4017B2, void, __thiscall, RefreshTitleBar, void* pThis)
 GAMECALL(0x40C3E0, void, __thiscall, CFrameWnd_ShowStatusBar, HWND* pThis, HWND hWnd)
 GAMECALL(0x4A3BDF, struct CWnd *, __stdcall, CWnd_FromHandle, HWND hWnd)
+GAMECALL(0x4AA573, void, __thiscall, CWinApp_OnAppExit, void *pThis)
 GAMECALL(0x4AE0BC, void, __thiscall, CDocument_UpdateAllViews, void* pThis, void* pSender, int lHint, void* pHint)
 GAMECALL(0x4B234F, int, __stdcall, AfxMessageBox, unsigned int nIDPrompt, unsigned int nType, unsigned int nIDHelp)
 

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -16,10 +16,10 @@
 #include <json.hpp>
 
 // Turning this on enables every debugging option. You have been warned.
-#define DEBUGALL
+// #define DEBUGALL
 
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
-#define CONSOLE_ENABLED
+// #define CONSOLE_ENABLED
 
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -16,10 +16,10 @@
 #include <json.hpp>
 
 // Turning this on enables every debugging option. You have been warned.
-// #define DEBUGALL
+#define DEBUGALL
 
 // Turning this on forces the console to be enabled, as if -console was passed to SIMCITY.EXE.
-// #define CONSOLE_ENABLED
+#define CONSOLE_ENABLED
 
 #define SC2KVERSION_UNKNOWN 0
 #define SC2KVERSION_1995    1


### PR DESCRIPTION
If you click Cancel from the Exit requester it'll properly restore the simulation ticker (as opposed to previously where aspects were left frozen; this was an extremely old problem going back to the Windows 3.11 edition of the game).

Placing in draft for now. Let me know if there's anything amiss.