### PR TITLE
Quietly bypass the intro check

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -214,7 +214,6 @@ extern "C" DWORD __cdecl Hook_SmackOpen(LPCSTR lpFileName, uint32_t uFlags, int3
 }
 
 extern "C" DWORD __cdecl Hook_MovieCheck(char *sMovStr) {
-
 	if (sMovStr && strncmp(sMovStr, "INTRO", 5) == 0) {
 		if (!smk_enabled || bSkipIntro || bSettingsAlwaysSkipIntro)
 			return 1;

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -201,7 +201,7 @@ extern "C" DWORD __cdecl Hook_SmackOpen(LPCSTR lpFileName, uint32_t uFlags, int3
 	if (mischook_debug & MISCHOOK_DEBUG_SMACK)
 		ConsoleLog(LOG_DEBUG, "SMK:  0x%08X -> _SmackOpen(%s, %u, %i)\n", _ReturnAddress(), lpFileName, uFlags, iExBuf);
 
-	if (bSkipIntro || bSettingsAlwaysSkipIntro)
+	if (!smk_enabled || bSkipIntro || bSettingsAlwaysSkipIntro)
 		if (strrchr(lpFileName, '\\'))
 			if (!strcmp(strrchr(lpFileName, '\\'), "\\INTROA.SMK") || !strcmp(strrchr(lpFileName, '\\'), "\\INTROB.SMK"))
 				return NULL;
@@ -211,6 +211,16 @@ extern "C" DWORD __cdecl Hook_SmackOpen(LPCSTR lpFileName, uint32_t uFlags, int3
 	memset(buf, 0, sizeof(buf));
 
 	return SMKOpenProc(AdjustSource(buf, lpFileName), uFlags, iExBuf);
+}
+
+extern "C" DWORD __cdecl Hook_MovieCheck(char *sMovStr) {
+
+	if (sMovStr && strncmp(sMovStr, "INTRO", 5) == 0) {
+		if (!smk_enabled || bSkipIntro || bSettingsAlwaysSkipIntro)
+			return 1;
+	}
+
+	return Game_Direct_MovieCheck(sMovStr);
 }
 
 extern "C" void __stdcall Hook_ApparentExit(void) {
@@ -905,6 +915,10 @@ void InstallMiscHooks(void) {
 		// Install Smacker function hooks
 		*(DWORD*)(0x4EFF00) = (DWORD)Hook_SmackOpen;
 	}
+
+	// Hook into the movie checking function.
+	VirtualProtect((LPVOID)0x402360, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
+	NEWJMP((LPVOID)0x402360, Hook_MovieCheck);
 
 	// Fix the sign fonts
 	VirtualProtect((LPVOID)0x4E7267, 1, PAGE_EXECUTE_READWRITE, &dwDummy);

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -806,6 +806,7 @@ GAMECALL(0x402B94, int, __cdecl, MapToolLevelTerrain, __int16 iTileTargetX, __in
 GAMECALL(0x402C25, int, __cdecl, CityToolMenuAction, int iMouseKeys, POINT pt)
 GAMECALL(0x402F9A, int, __thiscall, GetScreenAreaInfo, DWORD pThis, LPRECT lpRect)
 GAMECALL(0x480140, void, __stdcall, LoadSoundBuffer, int iSoundID, void* pBuffer)
+GAMECALL(0x48A810, DWORD, __cdecl, Direct_MovieCheck, char *sMovStr)
 
 
 // MFC function pointers. Use with care.


### PR DESCRIPTION
During the check of the introduction videos have it always return 1 if the skip flag is enabled and/or if the smacker library cannot be loaded.

The "Skipping in-flight movie" notice won't be displayed at that point.