### PR TITLE
More Military Fixes

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -638,8 +638,8 @@ extern "C" void _declspec(naked) Hook_SimulationStartDisaster(void) {
 }
 
 extern "C" int __cdecl Hook_SimulationPrepareDisaster(DWORD* a1, __int16 a2, __int16 a3) {
-	if (mischook_debug & MISCHOOK_DEBUG_DISASTERS)
-		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> SimulationPrepareDisaster(0x%08X, %i, %i).\n", _ReturnAddress(), a1, a2, a3);
+	//if (mischook_debug & MISCHOOK_DEBUG_DISASTERS)
+	//	ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> SimulationPrepareDisaster(0x%08X, %i, %i).\n", _ReturnAddress(), a1, a2, a3);
 
 	a1[0] = a2;
 	a1[1] = a3;

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -438,12 +438,9 @@ extern "C" int __cdecl Hook_ItemPlacementCheck(unsigned __int16 m_x, int m_y, __
 			if (iBuilding == TILE_SMALLPARK) {
 				return 0;
 			}
-			if (dwMapXZON[iX[0]]->b[iY[0]].iZoneType == ZONE_MILITARY) {
-				if (iBuilding == TILE_INFRASTRUCTURE_RUNWAYCROSS ||
-					iBuilding == TILE_ROAD_LR ||
-					iBuilding == TILE_ROAD_TB)
-					return 0;
-			}
+			//if (dwMapXZON[iX[0]]->b[iY[0]].iZoneType == ZONE_MILITARY) {
+			//	return 0;
+			//}
 			if (iTileID == TILE_INFRASTRUCTURE_MARINA) {
 				if ((unsigned __int16)iX[0] < 0x80u &&
 					(unsigned __int16)iY[0] < 0x80u &&

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -438,9 +438,12 @@ extern "C" int __cdecl Hook_ItemPlacementCheck(unsigned __int16 m_x, int m_y, __
 			if (iBuilding == TILE_SMALLPARK) {
 				return 0;
 			}
-			//if (dwMapXZON[iX[0]]->b[iY[0]].iZoneType == ZONE_MILITARY) {
-			//	return 0; // This is where it stops during the military zone checking process.
-			//}
+			if (dwMapXZON[iX[0]]->b[iY[0]].iZoneType == ZONE_MILITARY) {
+				if (iBuilding == TILE_INFRASTRUCTURE_RUNWAYCROSS ||
+					iBuilding == TILE_ROAD_LR ||
+					iBuilding == TILE_ROAD_TB)
+					return 0;
+			}
 			if (iTileID == TILE_INFRASTRUCTURE_MARINA) {
 				if ((unsigned __int16)iX[0] < 0x80u &&
 					(unsigned __int16)iY[0] < 0x80u &&

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -438,9 +438,12 @@ extern "C" int __cdecl Hook_ItemPlacementCheck(unsigned __int16 m_x, int m_y, __
 			if (iBuilding == TILE_SMALLPARK) {
 				return 0;
 			}
-			//if (dwMapXZON[iX[0]]->b[iY[0]].iZoneType == ZONE_MILITARY) {
-			//	return 0;
-			//}
+			if (dwMapXZON[iX[0]]->b[iY[0]].iZoneType == ZONE_MILITARY) {
+				if (iBuilding == TILE_INFRASTRUCTURE_RUNWAYCROSS ||
+					iBuilding == TILE_ROAD_LR ||
+					iBuilding == TILE_ROAD_TB)
+					return 0;
+			}
 			if (iTileID == TILE_INFRASTRUCTURE_MARINA) {
 				if ((unsigned __int16)iX[0] < 0x80u &&
 					(unsigned __int16)iY[0] < 0x80u &&
@@ -635,8 +638,8 @@ extern "C" void _declspec(naked) Hook_SimulationStartDisaster(void) {
 }
 
 extern "C" int __cdecl Hook_SimulationPrepareDisaster(DWORD* a1, __int16 a2, __int16 a3) {
-	//if (mischook_debug & MISCHOOK_DEBUG_DISASTERS)
-	//	ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> SimulationPrepareDisaster(0x%08X, %i, %i).\n", _ReturnAddress(), a1, a2, a3);
+	if (mischook_debug & MISCHOOK_DEBUG_DISASTERS)
+		ConsoleLog(LOG_DEBUG, "MISC: 0x%08X -> SimulationPrepareDisaster(0x%08X, %i, %i).\n", _ReturnAddress(), a1, a2, a3);
 
 	a1[0] = a2;
 	a1[1] = a3;

--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -516,25 +516,25 @@ GOFORWARD:
 			if (iArea) {
 				if (x < 0x80u && (unsigned __int16)y < 0x80u) {
 					pZone = (BYTE *)&dwMapXZON[x]->b[y];
-					*pZone = P_LOBYTE(wSomePositionalAngleOne[4 * wViewRotation]) | *pZone & 0xF;
+					*pZone = LOBYTE(wSomePositionalAngleOne[4 * wViewRotation]) | *pZone & 0xF;
 				}
 				iSection[0] = iArea + x;
 				if ((__int16)(iArea + x) > -1 && iSection[0] < 128 && (unsigned __int16)y < 0x80u) {
 					pZone = (BYTE *)&dwMapXZON[iSection[0]]->b[y];
-					*pZone = P_LOBYTE(wSomePositionalAngleTwo[4 * wViewRotation]) | *pZone & 0xF;
+					*pZone = LOBYTE(wSomePositionalAngleTwo[4 * wViewRotation]) | *pZone & 0xF;
 				}
 				if ((unsigned __int16)iSection[0] < 0x80u) {
 					iSection[1] = y + iArea;
 					if ((__int16)(y + iArea) > -1 && iSection[1] < 128) {
 						pZone = (BYTE *)&dwMapXZON[iSection[0]]->b[iSection[1]];
-						*pZone = P_LOBYTE(wSomePositionalAngleThree[4 * wViewRotation]) | *pZone & 0xF;
+						*pZone = LOBYTE(wSomePositionalAngleThree[4 * wViewRotation]) | *pZone & 0xF;
 					}
 				}
 				if (x < 0x80u) {
 					iSection[2] = iArea + y;
 					if ((__int16)(iArea + y) > -1 && iSection[2] < 128) {
 						pZone = (BYTE *)&dwMapXZON[x]->b[iSection[2]];
-						*pZone = P_LOBYTE(wSomePositionalAngleFour[4 * wViewRotation]) | *pZone & 0xF;
+						*pZone = LOBYTE(wSomePositionalAngleFour[4 * wViewRotation]) | *pZone & 0xF;
 					}
 				}
 			}

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -873,7 +873,7 @@ GAMEOFF(WORD,	wDisasterType,				0x4CA420)
 GAMEOFF(WORD,	wCityMode,					0x4CA42C)
 GAMEOFF(int,	dwCityLandValue,			0x4CA440)
 GAMEOFF(int,	dwCityFunds,				0x4CA444)
-GAMEOFF_ARR(WORD, dwTileCount,				0x4CA4C8)		// WORD dwTileCount[256]
+GAMEOFF(WORD*, dwTileCount,					0x4CA4C8)		// WORD dwTileCount[256]
 GAMEOFF(DWORD,	dwCityValue,				0x4CA4D0)
 GAMEOFF(DWORD,	dwCityGarbage,				0x4CA5F0)		// Unused in vanilla game (sort of)
 GAMEOFF(WORD,	wCityStartYear,				0x4CA5F4)

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -47,16 +47,6 @@
 #define lengthof(s) (countof(s)-1)
 
 // The nearest equivalent of LOWORD() from IDA.
-#define P_LAST_IND(x,part_type)    (sizeof(x)/sizeof(part_type) - 1)
-#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN
-#  define P_LOW_IND(x,part_type)   P_LAST_IND(x,part_type)
-#  define P_HIGH_IND(x,part_type)  0
-#else
-#  define P_HIGH_IND(x,part_type)  P_LAST_IND(x,part_type)
-#  define P_LOW_IND(x,part_type)   0
-#endif
-#define P_BYTEn(x, n) (*((BYTE*)&(x)+n))
-#define P_LOBYTE(x) P_BYTEn(x,P_LOW_IND(x,BYTE))
 #define P_LOWORD(x) (*((uint16_t*)&(x)))
 #define P_HIWORD(x) (*((uint16_t*)&(x)+1))
 // Signed

--- a/modules/kuroko_glue.cpp
+++ b/modules/kuroko_glue.cpp
@@ -302,7 +302,7 @@ extern "C" {
 		KRK_GAMEOFF(wMonsterXTHGIndex);
 		KRK_GAMEOFF(dwNationalPopulation);
 		KRK_GAMEOFF_PTR(dwNeighborFame);
-		KRK_GAMEOFF(dwMilitaryTiles);
+		KRK_GAMEOFF_PTR(dwMilitaryTiles);
 		KRK_GAMEOFF(wNationalTax);
 		KRK_GAMEOFF(wCurrentDisasterID);
 		KRK_GAMEOFF(dwCityOrdinances);

--- a/modules/military.cpp
+++ b/modules/military.cpp
@@ -28,6 +28,200 @@ UINT military_debug = MILITARY_DEBUG;
 
 static DWORD dwDummy;
 
+extern "C" __int16 __cdecl Hook_PlaceTileWithMilitaryCheck(__int16 x, __int16 y, __int16 iTileID) {
+#if 1
+	int result;
+	BYTE iCurrentBuilding;
+	BYTE *pCurrentBuilding;
+
+	result = iTileID;
+	if ( x < 0x80 && y < 0x80 ) {
+		pCurrentBuilding = &dwMapXBLD[x]->iTileID[y];
+		iCurrentBuilding = *pCurrentBuilding;
+		if ( dwMapXZON[x]->b[y].iZoneType != ZONE_MILITARY ) {
+			--dwTileCount[iCurrentBuilding];
+			++dwTileCount[iTileID];
+			*pCurrentBuilding = (BYTE)iTileID;
+			return result;
+		}
+		if ( iCurrentBuilding < TILE_MILITARY_F15B ) {
+			if ( iCurrentBuilding < TILE_MILITARY_CONTROLTOWER ) {
+				if ( iCurrentBuilding < TILE_INFRASTRUCTURE_RUNWAYCROSS ) {
+					if ( iCurrentBuilding == TILE_INFRASTRUCTURE_RUNWAY ) {
+						--dwMilitaryTiles[1];
+						goto GOCHECKCURRENTTILE;
+					}
+				}
+				else {
+					if ( iCurrentBuilding <= TILE_INFRASTRUCTURE_RUNWAYCROSS ) {
+						--dwMilitaryTiles[2];
+						goto GOCHECKCURRENTTILE;
+					}
+					if ( iCurrentBuilding == TILE_INFRASTRUCTURE_CRANE ) {
+						--dwMilitaryTiles[10];
+						goto GOCHECKCURRENTTILE;
+					}
+				}
+			}
+			else {
+				if ( iCurrentBuilding <= TILE_MILITARY_CONTROLTOWER ) {
+					--dwMilitaryTiles[11];
+					goto GOCHECKCURRENTTILE;
+				}
+				if ( iCurrentBuilding < TILE_INFRASTRUCTURE_BUILDING1 ) {
+					--dwMilitaryTiles[6];
+					goto GOCHECKCURRENTTILE;
+				}
+				if ( iCurrentBuilding <= TILE_INFRASTRUCTURE_BUILDING1 ) {
+					--dwMilitaryTiles[7];
+					goto GOCHECKCURRENTTILE;
+				}
+				if ( iCurrentBuilding == TILE_INFRASTRUCTURE_BUILDING2 ) {
+					--dwMilitaryTiles[8];
+					goto GOCHECKCURRENTTILE;
+				}
+			}
+		}
+		else {
+			if ( iCurrentBuilding <= TILE_MILITARY_F15B ) {
+				--dwMilitaryTiles[12];
+				goto GOCHECKCURRENTTILE;
+			}
+			if ( iCurrentBuilding < TILE_MILITARY_TOPSECRET ) {
+				if ( iCurrentBuilding < TILE_MILITARY_RADAR ) {
+					if ( iCurrentBuilding == TILE_MILITARY_HANGAR1 ) {
+						--dwMilitaryTiles[13];
+						goto GOCHECKCURRENTTILE;
+					}
+				}
+				else {
+					if ( iCurrentBuilding <= TILE_MILITARY_RADAR ) {
+						--dwMilitaryTiles[5];
+						goto GOCHECKCURRENTTILE;
+					}
+					if ( iCurrentBuilding == TILE_MILITARY_PARKINGLOT ) {
+						--dwMilitaryTiles[3];
+						goto GOCHECKCURRENTTILE;
+					}
+				}
+			}
+			else {
+				if ( iCurrentBuilding <= TILE_MILITARY_TOPSECRET ) {
+					--dwMilitaryTiles[9];
+					goto GOCHECKCURRENTTILE;
+				}
+				if ( iCurrentBuilding < TILE_INFRASTRUCTURE_HANGAR2 ) {
+					if ( iCurrentBuilding == TILE_INFRASTRUCTURE_CARGOYARD ) {
+						--dwMilitaryTiles[4];
+						goto GOCHECKCURRENTTILE;
+					}
+				}
+				else {
+					if ( iCurrentBuilding <= TILE_INFRASTRUCTURE_HANGAR2 ) {
+						--dwMilitaryTiles[14];
+						goto GOCHECKCURRENTTILE;
+					}
+					if ( iCurrentBuilding == TILE_MILITARY_MISSILESILO ) {
+						--dwMilitaryTiles[15];
+						goto GOCHECKCURRENTTILE;
+					}
+				}
+			}
+		}
+		// New experimental check to attempt to avoid Army Base spawned roads from
+		// being overwritten by the Runway item if the MilitaryBase type switches
+		// to Airforce.
+		//if ( iTileID == TILE_INFRASTRUCTURE_RUNWAY )
+		//	if ( iCurrentBuilding >= TILE_ROAD_LR && iCurrentBuilding <= TILE_ROAD_LTBR )
+		//		return result;
+		//if ( iCurrentBuilding >= TILE_ROAD_LR && iCurrentBuilding <= TILE_ROAD_LTBR )
+		//	ConsoleLog(LOG_DEBUG, "DBG: 0x%06X -> PlaceTileWithMilitaryCheck(%d, %d, %s) iCurrentBuilding(%s)\n", _ReturnAddress(), x, y, szTileNames[iTileID], szTileNames[iCurrentBuilding]);
+		--*dwMilitaryTiles;
+	GOCHECKCURRENTTILE:
+		if ( iTileID < TILE_MILITARY_F15B ) {
+			if ( iTileID < TILE_MILITARY_CONTROLTOWER ) {
+				if ( iTileID < TILE_INFRASTRUCTURE_RUNWAYCROSS ) {
+					if ( iTileID != TILE_INFRASTRUCTURE_RUNWAY ) {
+					GOBACKCHECKTILE:
+						++*dwMilitaryTiles;
+						goto GOFORWARDGETOUT;
+					}
+					++dwMilitaryTiles[1];
+				}
+				else if ( iTileID <= TILE_INFRASTRUCTURE_RUNWAYCROSS ) {
+					++dwMilitaryTiles[2];
+				}
+				else {
+					if ( iTileID != TILE_INFRASTRUCTURE_CRANE )
+						goto GOBACKCHECKTILE;
+					++dwMilitaryTiles[10];
+				}
+			}
+			else if ( iTileID <= TILE_MILITARY_CONTROLTOWER ) {
+				++dwMilitaryTiles[11];
+			}
+			else if ( iTileID < TILE_INFRASTRUCTURE_BUILDING1 ) {
+				++dwMilitaryTiles[6];
+			}
+			else if ( iTileID <= TILE_INFRASTRUCTURE_BUILDING1 ) {
+				++dwMilitaryTiles[7];
+			}
+			else {
+				if ( iTileID != TILE_INFRASTRUCTURE_BUILDING2 )
+					goto GOBACKCHECKTILE;
+				++dwMilitaryTiles[8];
+			}
+		}
+		else if ( iTileID <= TILE_MILITARY_F15B ) {
+			++dwMilitaryTiles[12];
+		}
+		else if ( iTileID < TILE_MILITARY_TOPSECRET ) {
+			if ( iTileID < TILE_MILITARY_RADAR ) {
+				if ( iTileID != TILE_MILITARY_HANGAR1 )
+					goto GOBACKCHECKTILE;
+				++dwMilitaryTiles[13];
+			}
+			else if ( iTileID <= TILE_MILITARY_RADAR ) {
+				++dwMilitaryTiles[5];
+			}
+			else {
+				if ( iTileID != TILE_MILITARY_PARKINGLOT )
+					goto GOBACKCHECKTILE;
+				++dwMilitaryTiles[3];
+			}
+		}
+		else if ( iTileID <= TILE_MILITARY_TOPSECRET ) {
+			++dwMilitaryTiles[9];
+		}
+		else if ( iTileID < TILE_INFRASTRUCTURE_HANGAR2 ) {
+			if ( iTileID != TILE_INFRASTRUCTURE_CARGOYARD )
+				goto GOBACKCHECKTILE;
+			++dwMilitaryTiles[4];
+		}
+		else if ( iTileID <= TILE_INFRASTRUCTURE_HANGAR2 ) {
+			++dwMilitaryTiles[14];
+		}
+		else {
+			if ( iTileID != TILE_MILITARY_MISSILESILO )
+				goto GOBACKCHECKTILE;
+			++dwMilitaryTiles[15];
+		}
+	GOFORWARDGETOUT:
+		*pCurrentBuilding = (BYTE)iTileID;
+	}
+	return result;
+#else
+	__int16(__cdecl *H_PlaceTileWithMilitaryCheck)(__int16, __int16, __int16) = (__int16(__cdecl *)(__int16, __int16, __int16))0x441F00;
+
+	__int16 ret = H_PlaceTileWithMilitaryCheck(x, y, iTileID);
+
+	if (iTileID == TILE_INFRASTRUCTURE_RUNWAY)
+		ConsoleLog(LOG_DEBUG, "DBG: 0x%06X -> PlaceTileWithMilitaryCheck(%d, %d, %d) = %d\n", _ReturnAddress(), x, y, iTileID, ret);
+
+	return ret;
+#endif
+}
+
 // This function has been replicated from he equivalent that was found
 // in the DOS version of the game.
 static void FormArmyBaseStrip(int x1, int y1, __int16 x2, __int16 y2) {
@@ -539,6 +733,9 @@ NONAVY:
 }
 
 void InstallMilitaryHooks(void) {
+	VirtualProtect((LPVOID)0x40178F, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
+	NEWJMP((LPVOID)0x40178F, Hook_PlaceTileWithMilitaryCheck);
+
 	// Replicate the general functionality provided from the DOS version
 	// to also include the Navy and Army Base spawning.
 	VirtualProtect((LPVOID)0x403017, 5, PAGE_EXECUTE_READWRITE, &dwDummy);

--- a/modules/military.cpp
+++ b/modules/military.cpp
@@ -29,7 +29,7 @@ UINT military_debug = MILITARY_DEBUG;
 static DWORD dwDummy;
 
 extern "C" __int16 __cdecl Hook_PlaceTileWithMilitaryCheck(__int16 x, __int16 y, __int16 iTileID) {
-#if 1
+#if 0
 	int result;
 	BYTE iCurrentBuilding;
 	BYTE *pCurrentBuilding;
@@ -128,14 +128,6 @@ extern "C" __int16 __cdecl Hook_PlaceTileWithMilitaryCheck(__int16 x, __int16 y,
 				}
 			}
 		}
-		// New experimental check to attempt to avoid Army Base spawned roads from
-		// being overwritten by the Runway item if the MilitaryBase type switches
-		// to Airforce.
-		//if ( iTileID == TILE_INFRASTRUCTURE_RUNWAY )
-		//	if ( iCurrentBuilding >= TILE_ROAD_LR && iCurrentBuilding <= TILE_ROAD_LTBR )
-		//		return result;
-		//if ( iCurrentBuilding >= TILE_ROAD_LR && iCurrentBuilding <= TILE_ROAD_LTBR )
-		//	ConsoleLog(LOG_DEBUG, "DBG: 0x%06X -> PlaceTileWithMilitaryCheck(%d, %d, %s) iCurrentBuilding(%s)\n", _ReturnAddress(), x, y, szTileNames[iTileID], szTileNames[iCurrentBuilding]);
 		--*dwMilitaryTiles;
 	GOCHECKCURRENTTILE:
 		if ( iTileID < TILE_MILITARY_F15B ) {
@@ -215,9 +207,6 @@ extern "C" __int16 __cdecl Hook_PlaceTileWithMilitaryCheck(__int16 x, __int16 y,
 
 	__int16 ret = H_PlaceTileWithMilitaryCheck(x, y, iTileID);
 
-	if (iTileID == TILE_INFRASTRUCTURE_RUNWAY)
-		ConsoleLog(LOG_DEBUG, "DBG: 0x%06X -> PlaceTileWithMilitaryCheck(%d, %d, %d) = %d\n", _ReturnAddress(), x, y, iTileID, ret);
-
 	return ret;
 #endif
 }
@@ -231,6 +220,14 @@ static void FormArmyBaseStrip(int x1, int y1, __int16 x2, __int16 y2) {
 	int iNewX;
 	int iNewY;
 
+	// NOTE: ZoneType 0xF0 "appears" to be for preventing the tiles in
+	// question from being charged back during the budget cycle.
+	// It also seems that if you spam "gilmartin" often enough and get
+	// plenty of Army Base spawns, on a completely empty but military
+	// populated map you'll start to earn a $1 a year bonus that's
+	// applied to the transportation budget (whether this is additive
+	// over time on a populated city is unclear).
+
 	wOldToolGroup = wMaybeActiveToolGroup;
 	iX = x2;
 	iY = y2;
@@ -241,32 +238,32 @@ static void FormArmyBaseStrip(int x1, int y1, __int16 x2, __int16 y2) {
 		iNewY = y1;
 		iY = y1;
 		while (Game_MaybeRoadViabilityAlongPath((__int16 *)&iNewX, (__int16 *)&iNewY)) {
-			dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
 			Game_CheckAndAdjustTransportTerrain(iX, iY);
 			Game_PlaceRoadAtCoordinates(iX, iY);
+			dwMapXZON[iX]->b[iY].iZoneType = 0xF0;
 			iX = iNewX;
 			iY = iNewY;
 		}
-		dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
 		Game_CheckAndAdjustTransportTerrain(iX, iY);
 		Game_PlaceRoadAtCoordinates(iX, iY);
+		dwMapXZON[iX]->b[iY].iZoneType = 0xF0;
 	}
 	if (GetTileID(x1, y1) == TILE_ROAD_LR || GetTileID(x1, y1) == TILE_ROAD_TB) {
 		// TERRAIN_00 check added here to avoid the runwaycross
 		// being placed into a dip (likely replacing a slope or granite block).
 		if (!dwMapXTER[x1]->iTileID[y1]) {
-			dwMapXZON[x1]->b[y1].iZoneType = ZONE_MILITARY;
-			dwMapXZON[x1]->b[y1].iCorners = 0x0F; // In the DOS build this is 0xF0, however that value here results in a blank area.
 			Game_PlaceTileWithMilitaryCheck(x1, y1, TILE_INFRASTRUCTURE_RUNWAYCROSS);
+			dwMapXZON[x1]->b[y1].iZoneType = 0xF0;
+			dwMapXZON[x1]->b[y1].iCorners = 0xF;
 		}
 	}
 	if (GetTileID(iX, iY) == TILE_ROAD_LR || GetTileID(iX, iY) == TILE_ROAD_TB) {
 		// TERRAIN_00 check added here to avoid the runwaycross
 		// being placed into a dip (likely replacing a slope or granite block).
 		if (!dwMapXTER[iX]->iTileID[iY]) {
-			dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
-			dwMapXZON[iX]->b[iY].iCorners = 0x0F; // In the DOS build this is 0xF0, however that value here results in a blank area.
 			Game_PlaceTileWithMilitaryCheck(iX, iY, TILE_INFRASTRUCTURE_RUNWAYCROSS);
+			dwMapXZON[iX]->b[iY].iZoneType = 0xF0;
+			dwMapXZON[iX]->b[iY].iCorners = 0xF;
 		}
 	}
 	wMaybeActiveToolGroup = wOldToolGroup;

--- a/modules/military.cpp
+++ b/modules/military.cpp
@@ -47,11 +47,13 @@ static void FormArmyBaseStrip(int x1, int y1, __int16 x2, __int16 y2) {
 		iNewY = y1;
 		iY = y1;
 		while (Game_MaybeRoadViabilityAlongPath((__int16 *)&iNewX, (__int16 *)&iNewY)) {
+			dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
 			Game_CheckAndAdjustTransportTerrain(iX, iY);
 			Game_PlaceRoadAtCoordinates(iX, iY);
 			iX = iNewX;
 			iY = iNewY;
 		}
+		dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
 		Game_CheckAndAdjustTransportTerrain(iX, iY);
 		Game_PlaceRoadAtCoordinates(iX, iY);
 	}
@@ -354,8 +356,8 @@ REROLLCOASTALSPOT:
 								Game_PlaceTileWithMilitaryCheck(iDirectionOne, iDirectionTwo, 0);
 								dwMapXZON[iDirectionOne]->b[iDirectionTwo].iZoneType = ZONE_MILITARY;
 								dwMapXZON[iDirectionOne]->b[iDirectionTwo].iCorners = 0xF0;
-								--*((WORD *)&dwTileCount + iMilitaryArea);
-								++*(WORD *)dwMilitaryTiles;
+								--dwTileCount[iMilitaryArea];
+								++*dwMilitaryTiles;
 								iNumTiles++;
 							}
 
@@ -454,9 +456,9 @@ NONAVY:
 					iPos[0] = dwSiloPos[2 * i];
 					iPos[1] = iPos[0];
 					for (k = dwSiloPos[2 * i + 1]; iPos[1] + 3 > (__int16)iPos[0]; P_LOWORD(iPos[0]) = iPos[0] + 1) {
-						for (uPos[0] = k; k + 3 > (__int16)uPos[0]; ++*(WORD *)dwMilitaryTiles) {
+						for (uPos[0] = k; k + 3 > (__int16)uPos[0]; ++*dwMilitaryTiles) {
 							iBuildingArea = dwMapXBLD[iPos[0]]->iTileID[uPos[0]];
-							--*((WORD *)&dwTileCount + iBuildingArea);
+							--dwTileCount[iBuildingArea];
 							if ((unsigned __int16)iPos[0] < 0x80u && uPos[0] < 0x80u) {
 								dwMapXZON[iPos[0]]->b[uPos[0]].iZoneType = ZONE_MILITARY;
 								dwMapXZON[iPos[0]]->b[uPos[0]].iCorners = 0xF0;
@@ -500,12 +502,12 @@ NONAVY:
 						dwMapXZON[uPos[0]]->b[uPos[1]].iZoneType == ZONE_NONE &&
 						!dwMapXUND[iRandOne[0]]->iTileID[iPosOffset]
 					) {
-						--*((WORD *)&dwTileCount + iMilitaryArea);
+						--dwTileCount[iMilitaryArea];
 						if (uPos[0] < 0x80u && uPos[1] < 0x80u) {
 							dwMapXZON[uPos[0]]->b[uPos[1]].iZoneType = ZONE_MILITARY;
 							dwMapXZON[uPos[0]]->b[uPos[1]].iCorners = 0xF0;
 						}
-						++*(WORD *)dwMilitaryTiles;
+						++*dwMilitaryTiles;
 					}
 				}
 			}

--- a/modules/military.cpp
+++ b/modules/military.cpp
@@ -220,14 +220,6 @@ static void FormArmyBaseStrip(int x1, int y1, __int16 x2, __int16 y2) {
 	int iNewX;
 	int iNewY;
 
-	// NOTE: ZoneType 0xF0 "appears" to be for preventing the tiles in
-	// question from being charged back during the budget cycle.
-	// It also seems that if you spam "gilmartin" often enough and get
-	// plenty of Army Base spawns, on a completely empty but military
-	// populated map you'll start to earn a $1 a year bonus that's
-	// applied to the transportation budget (whether this is additive
-	// over time on a populated city is unclear).
-
 	wOldToolGroup = wMaybeActiveToolGroup;
 	iX = x2;
 	iY = y2;
@@ -238,32 +230,30 @@ static void FormArmyBaseStrip(int x1, int y1, __int16 x2, __int16 y2) {
 		iNewY = y1;
 		iY = y1;
 		while (Game_MaybeRoadViabilityAlongPath((__int16 *)&iNewX, (__int16 *)&iNewY)) {
+			dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
 			Game_CheckAndAdjustTransportTerrain(iX, iY);
 			Game_PlaceRoadAtCoordinates(iX, iY);
-			dwMapXZON[iX]->b[iY].iZoneType = 0xF0;
 			iX = iNewX;
 			iY = iNewY;
 		}
+		dwMapXZON[iX]->b[iY].iZoneType = ZONE_MILITARY;
 		Game_CheckAndAdjustTransportTerrain(iX, iY);
 		Game_PlaceRoadAtCoordinates(iX, iY);
-		dwMapXZON[iX]->b[iY].iZoneType = 0xF0;
 	}
 	if (GetTileID(x1, y1) == TILE_ROAD_LR || GetTileID(x1, y1) == TILE_ROAD_TB) {
 		// TERRAIN_00 check added here to avoid the runwaycross
 		// being placed into a dip (likely replacing a slope or granite block).
 		if (!dwMapXTER[x1]->iTileID[y1]) {
-			Game_PlaceTileWithMilitaryCheck(x1, y1, TILE_INFRASTRUCTURE_RUNWAYCROSS);
-			dwMapXZON[x1]->b[y1].iZoneType = 0xF0;
 			dwMapXZON[x1]->b[y1].iCorners = 0xF;
+			Game_PlaceTileWithMilitaryCheck(x1, y1, TILE_INFRASTRUCTURE_RUNWAYCROSS);
 		}
 	}
 	if (GetTileID(iX, iY) == TILE_ROAD_LR || GetTileID(iX, iY) == TILE_ROAD_TB) {
 		// TERRAIN_00 check added here to avoid the runwaycross
 		// being placed into a dip (likely replacing a slope or granite block).
 		if (!dwMapXTER[iX]->iTileID[iY]) {
-			Game_PlaceTileWithMilitaryCheck(iX, iY, TILE_INFRASTRUCTURE_RUNWAYCROSS);
-			dwMapXZON[iX]->b[iY].iZoneType = 0xF0;
 			dwMapXZON[iX]->b[iY].iCorners = 0xF;
+			Game_PlaceTileWithMilitaryCheck(iX, iY, TILE_INFRASTRUCTURE_RUNWAYCROSS);
 		}
 	}
 	wMaybeActiveToolGroup = wOldToolGroup;


### PR DESCRIPTION
1) The zone is (re)set on each potential road tile (this accounts for water, non-flat or granite tiles that wouldn't normally have the zone applied), this avoids the army-spawned roads from being charged to the budget.
2) Mystery solved concerning the value set for iCorners in DOS, it was 0xF all along.
3) Resolved some stability issues concerning both dwTileCount and dwMilitaryTiles being touched.
4) Added a hook for PlaceTileWithMilitaryCheck(), at the moment all it does is pass-through to the normal game function.