### PR TITLE
Naval spawning adjustments and Misc

### DIFF
--- a/hooks/hook_miscellaneous.cpp
+++ b/hooks/hook_miscellaneous.cpp
@@ -1365,7 +1365,16 @@ extern "C" int __cdecl Hook_ItemPlacementCheck(unsigned __int16 m_x, int m_y, __
 					return 0;
 			}
 			else if (iX < 1 || iY < 1 || iX > GAME_MAP_SIZE-2 || iY > GAME_MAP_SIZE-2) {
-				return 0;
+				// Added this due to legacy military plot drops, this allows > 1x1 type buildings
+				// to develop if the plot is on the edge of the map.
+				if (dwMapXZON[iX][iY].b.iZoneType == ZONE_MILITARY) {
+					if (iX < 0 || iY < 0 || iX > GAME_MAP_SIZE - 1 || iY > GAME_MAP_SIZE - 1) {
+						return 0;
+					}
+				}
+				else {
+					return 0;
+				}
 			}
 			iBuilding = dwMapXBLD[iX][iY].iTileID;
 			if (iBuilding >= TILE_ROAD_LR) {

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -987,7 +987,7 @@ GAMECALL(0x402B3F, __int16, __stdcall, RandomWordLFSRMod128, int seed)
 // Pointers
 
 GAMEOFF_PTR(void, pCWinAppThis,				0x4C7010)
-GAMEOFF(void*,	pCWndRootWindow,			0x4C702C)
+GAMEOFF(void*,	pCWndRootWindow,			0x4C702C)		// CMainFrame
 GAMEOFF(BOOL,	bPriscillaActivated,		0x4C7104)
 GAMEOFF(DWORD*, dwAudioHandle,				0x4C7158)		// Various checks have pointed towards audio (sound and/or midi - perhaps stoppage given some context elsewhere)
 GAMEOFF(BOOL,	bOptionsMusicEnabled,		0x4C71F0)


### PR DESCRIPTION
The following has been done:
1) Naval Spawning adjustments:
    a) A two-step process has been introduced so that the number of tiles can first be calculated.
    b) A minimum tile number check has been added to avoid the "stub" base cases
    c)  A depth check has been added to avoid certain non-contiguous placement cases
    d) Adjustments to the near and far width checks to ensure a base width >= 6 && <= 12 tiles in length.
2) Air Force and Army Base plot checker has been adjusted to avoid placing the base directly on the map edge (this is to avoid legacy problems concerning > 1x1 building spawning failing).
3) Related to (2) the ItemPlacementCheck function has been adjusted so that for military-specific areas the > 1x1 buildings will properly spawn (barring one cosmetic anomaly concerning "bedrock" tiles appearing on the edge-placed > 1x1 building depending on the corner case and view rotation).
4) Remove the hook concerning PlaceMilitaryTileWithCheck - this was to do with a previously concluded set of tracing.