### PR TITLE
Added 'ReleaseNoKuroko' build option

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -19,8 +19,10 @@
 #include <winmm_exports.h>
 #include "resource.h"
 
+#if !NOKUROKO
 #include <kuroko/kuroko.h>
 #include <kuroko/util.h>
+#endif
 
 #pragma comment(lib, "comctl32.lib")
 #pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
@@ -43,7 +45,9 @@ const char* szSC2KFixReleaseTag = SC2KFIX_RELEASE_TAG;
 const char* szSC2KFixBuildInfo = __DATE__ " " __TIME__;
 FILE* fdLog = NULL;
 BOOL bInSCURK = FALSE;
+#if !NOKUROKO
 BOOL bKurokoVMInitialized = FALSE;
+#endif
 BOOL bUseAdvancedQuery = FALSE;
 BOOL bSkipLoadingMods = FALSE;
 int iForcedBits = 0;
@@ -127,7 +131,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 						mci_debug = DEBUG_FLAGS_EVERYTHING;
 						military_debug = DEBUG_FLAGS_EVERYTHING;
 						mischook_debug = DEBUG_FLAGS_EVERYTHING;
+#if !NOKUROKO
 						modloader_debug = DEBUG_FLAGS_EVERYTHING;
+#endif
 						mus_debug = DEBUG_FLAGS_EVERYTHING;
 						registry_debug = DEBUG_FLAGS_EVERYTHING;
 						sc2x_debug = DEBUG_FLAGS_EVERYTHING;
@@ -425,9 +431,14 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		// Start the console thread.
 		if (bConsoleEnabled) {
 			ConsoleLog(LOG_INFO, "CORE: Starting console thread.\n");
+#if !NOKUROKO
 			hConsoleThread = CreateThread(NULL, 0, ConsoleThread, 0, 0, &dwConsoleThreadID);
+#else
+			hConsoleThread = CreateThread(NULL, 0, ConsoleThread, 0, 0, NULL);
+#endif
 		}
 
+#if !NOKUROKO
 		// Set up the modding infrastructure for the 1996 Special Edition version.
 		if (dwDetectedVersion == SC2KVERSION_1996) {
 			// Initialize the Kuroko VM
@@ -437,6 +448,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 			if (!bSkipLoadingMods && !bSettingsDontLoadMods)
 				LoadNativeCodeMods();
 		}
+#endif
 
 		break;
 
@@ -450,9 +462,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		// Shut down the music thread
 		PostThreadMessage(dwMusicThreadID, WM_QUIT, NULL, NULL);
 
+#if !NOKUROKO
 		// Shut down the Kuroko thread
 		if (bKurokoVMInitialized)
 			PostThreadMessage(dwKurokoThreadID, WM_QUIT, NULL, NULL);
+#endif
 
 		// Only save the stored paths during a graceful exit. (SC2K1996 only for now)
 		if (!bGameDead)

--- a/hooks/hook_sc2k1996_miscellaneous.cpp
+++ b/hooks/hook_sc2k1996_miscellaneous.cpp
@@ -377,7 +377,9 @@ extern "C" void __stdcall Hook_CCmdUI_Enable(BOOL bOn) {
 
 	// Ensure the main config menu options are always enabled
 	EnableMenuItem(GetMenu(GameGetRootWindowHandle()), IDM_GAME_OPTIONS_SC2KFIXSETTINGS, MF_BYCOMMAND | MF_ENABLED);
+#if !NOKUROKO
 	EnableMenuItem(GetMenu(GameGetRootWindowHandle()), IDM_GAME_OPTIONS_MODCONFIG, MF_BYCOMMAND | MF_ENABLED);
+#endif
 
 	// Only enable the Scenario Goals option if we need it
 	if (bInScenario)
@@ -393,6 +395,7 @@ extern "C" void __stdcall Hook_CCmdUI_Enable(BOOL bOn) {
 	EnableMenuItem(GetMenu(GameGetRootWindowHandle()), IDM_DEBUG_MILITARY_MISSILESILOS, MF_BYCOMMAND | MF_ENABLED);
 }
 
+#if !NOKUROKO
 // Function prototype: HOOKCB void Hook_GameDoIdleUpkeep_Before(void)
 // Ignored if bHookStopProcessing == TRUE.
 // SPECIAL NOTE: Ignoring this hook on callback results in the game effectively hanging. You have
@@ -435,6 +438,7 @@ extern "C" void __stdcall Hook_GameDoIdleUpkeep(void) {
 BAIL:
 	return;
 }
+#endif
 
 // Fix the missing "Maxis Presents" slide
 void __declspec(naked) Hook_4062AD(void) {
@@ -446,11 +450,13 @@ void __declspec(naked) Hook_4062AD(void) {
 	}
 }
 
+#if !NOKUROKO
 // Function prototype: HOOKCB void Hook_OnNewCity_Before(void)
 // Cannot be ignored.
 // SPECIAL NOTE: I cannot for the life of me remember why I added this. It will almost certainly
 //   be replaced within the next three months (comment added 2025-08-15).
 std::vector<hook_function_t> stHooks_Hook_OnNewCity_Before;
+#endif
 
 static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 	switch (message) {
@@ -536,6 +542,7 @@ static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM w
 
 		strcpy_s(dwMapXLAB[0][0].szLabel, 24, szTempMayorName);
 
+#if !NOKUROKO
 		// XXX - this should probably be moved to a separate proper hook into the game itself
 		for (const auto& hook : stHooks_Hook_OnNewCity_Before) {
 			bHookStopProcessing = FALSE;
@@ -544,6 +551,7 @@ static BOOL CALLBACK Hook_NewCityDialogProc(HWND hwndDlg, UINT message, WPARAM w
 				fnHook();
 			}
 		}
+#endif
 		break;
 	}
 
@@ -1899,7 +1907,7 @@ static void UpdateCityDateAndSeason(BOOL bIncrement) {
 	wCityElapsedYears = dwCityDays / 300;
 }
 
-
+#if !NOKUROKO
 // Function prototype: HOOKCB void Hook_SimCalendarAdvance_Before(void)
 // Called before the vanilla SimCalendar day simulation. Cannot be ignored.
 std::vector<hook_function_t> stHooks_Hook_SimCalendarAdvance_Before;
@@ -1912,6 +1920,7 @@ std::vector<hook_function_t> stHooks_Hook_ScenarioSuccessCheck;
 // Function prototype: HOOKCB void Hook_SimCalendarAdvance_After(void)
 // Called after the vanilla SimCalendar day simulation. Cannot be ignored.
 std::vector<hook_function_t> stHooks_Hook_SimCalendarAdvance_After;
+#endif
 
 extern "C" void __stdcall Hook_SimulationProcessTick() {
 	int i;
@@ -1968,6 +1977,7 @@ extern "C" void __stdcall Hook_SimulationProcessTick() {
 		Game_CDocument_UpdateAllViews(pCDocumentMainWindow, NULL, 2, NULL);
 	}
 
+#if !NOKUROKO
 	// Call mods for daily processing tasks - before update
 	// XXX - should mods be able to entirely override SimCalendar days? Perhaps this is more a
 	// theological discussion to be held...
@@ -1977,6 +1987,7 @@ extern "C" void __stdcall Hook_SimulationProcessTick() {
 			fnHook();
 		}
 	}
+#endif
 
 	// Advance the simulation for the current SimCalendar day
 	switch (dwMonDay) {
@@ -2077,6 +2088,7 @@ extern "C" void __stdcall Hook_SimulationProcessTick() {
 						bScenarioSuccess = FALSE;
 				}
 
+#if !NOKUROKO
 				// Iterate through mod-based scenario goals
 				for (const auto& hook : stHooks_Hook_ScenarioSuccessCheck) {
 					if (hook.iType == HOOKFN_TYPE_NATIVE) {
@@ -2085,6 +2097,7 @@ extern "C" void __stdcall Hook_SimulationProcessTick() {
 							bScenarioSuccess = FALSE;
 					}
 				}
+#endif
 
 				// Declare victory if the player has met the requirements, or tick down towards
 				// failure if they haven't
@@ -2125,6 +2138,7 @@ extern "C" void __stdcall Hook_SimulationProcessTick() {
 			return;
 	}
 
+#if !NOKUROKO
 	// Call mods for daily processing tasks - after update
 	for (const auto& hook : stHooks_Hook_SimCalendarAdvance_After) {
 		if (hook.iType == HOOKFN_TYPE_NATIVE) {
@@ -2132,6 +2146,7 @@ extern "C" void __stdcall Hook_SimulationProcessTick() {
 			fnHook();
 		}
 	}
+#endif
 
 	// Explanation:
 	// !bSettingsFrequentCityRefresh - It will do the tile highlight update if:
@@ -2762,9 +2777,11 @@ static BOOL L_OnCmdMsg(void *pThis, UINT nID, int nCode, void *pExtra, void *pHa
 				ShowSettingsDialog();
 				return TRUE;
 
+#if !NOKUROKO
 			case IDM_GAME_OPTIONS_MODCONFIG:
 				ShowModSettingsDialog();
 				return TRUE;
+#endif
 
 			case IDM_DEBUG_MILITARY_DECLINED:
 				ProposeMilitaryBaseDecline();
@@ -2864,10 +2881,12 @@ extern "C" BOOL __stdcall Hook_WndOnCommand(WPARAM wParam, LPARAM lParam) {
 	return L_OnCmdMsg(pThis, nID, nCode, 0, 0, _ReturnAddress());
 }
 
+#if !NOKUROKO
 // Placeholder.
 void ShowModSettingsDialog(void) {
 	L_MessageBoxA(GameGetRootWindowHandle(), "The mod settings dialog has not yet been implemented. Check back later.", "sc2fix", MB_OK);
 }
+#endif
 
 // Install hooks and run code that we only want to do for the 1996 Special Edition SIMCITY.EXE.
 // This should probably have a better name. And maybe be broken out into smaller functions.
@@ -2910,9 +2929,11 @@ void InstallMiscHooks_SC2K1996(void) {
 
 	InstallSpriteAndTileSetSimCity1996Hooks();
 
+#if !NOKUROKO
 	// Hook GameDoIdleUpkeep
 	VirtualProtect((LPVOID)0x402A3B, 5, PAGE_EXECUTE_READWRITE, &dwDummy);
 	NEWJMP((LPVOID)0x402A3B, Hook_GameDoIdleUpkeep);
+#endif
 
 	// Fix the Maxis Presents logo not being shown
 	VirtualProtect((LPVOID)0x4062B9, 4, PAGE_EXECUTE_READWRITE, &dwDummy);
@@ -3052,10 +3073,12 @@ void InstallMiscHooks_SC2K1996(void) {
 			ConsoleLog(LOG_DEBUG, "MISC: Game InsertMenuA #2 failed, error = 0x%08X.\n", GetLastError());
 			goto skipgamemenu;
 		}
+#if !NOKUROKO
 		if (!InsertMenu(hOptionsPopup, -1, MF_BYPOSITION|MF_STRING, IDM_GAME_OPTIONS_MODCONFIG, "Mod &Configuration...") && mischook_debug & MISCHOOK_DEBUG_MENU) {
 			ConsoleLog(LOG_DEBUG, "MISC: Game InsertMenuA #3 failed, error = 0x%08X.\n", GetLastError());
 			goto skipgamemenu;
 		}
+#endif
 
 		// Windows menu -> add Show Scenario Goals...
 		HMENU hMenuWindowsPopup;

--- a/include/sc2k_1996.h
+++ b/include/sc2k_1996.h
@@ -19,7 +19,11 @@
 #include <vector>
 
 #ifndef HOOKEXT
+#if !NOKUROKO
 #define HOOKEXT extern "C" __declspec(dllexport)
+#else
+#define HOOKEXT extern "C"
+#endif
 #endif
 
 #ifdef GAMEOFF_IMPL

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -39,10 +39,15 @@
 #define SC2KFIX_RELEASE_TAG		"r9d"
 
 #define SC2KFIX_INIFILE		"sc2kfix.ini"
+#if !NOKUROKO
 #define SC2KFIX_MODSFOLDER	"mods"
 
 #define HOOKEXT extern "C" __declspec(dllexport)
 #define HOOKEXT_CPP __declspec(dllexport)
+#else
+#define HOOKEXT extern "C"
+#define HOOKEXT_CPP
+#endif
 
 #include <json.hpp>
 
@@ -80,9 +85,11 @@
 #define DEBUG_FLAGS_NONE		0
 #define DEBUG_FLAGS_EVERYTHING	0xFFFFFFFF
 
+#if !NOKUROKO
 #define WM_KUROKO_REPL	WM_APP+0x10
 #define WM_KUROKO_FILE	WM_APP+0x11
 #define WM_CONSOLE_REPL	WM_APP+0x20
+#endif
 
 #define HICOLORCNT 256
 #define LOCOLORCNT 16
@@ -113,6 +120,7 @@ public:
 	char *pStr;
 };
 
+#if !NOKUROKO
 // Struct defining an injected hook from a loaded mod and its nested call priority.
 typedef struct {
 	const char* szHookName;
@@ -155,6 +163,7 @@ typedef struct {
 } hook_function_t;
 
 #include <hooklists.h>
+#endif
 
 typedef BOOL (*console_cmdproc_t)(const char* szCommand, const char* szArguments);
 
@@ -244,11 +253,15 @@ void InitializeFonts(void);
 HOOKEXT void CenterDialogBox(HWND hwndDlg);
 HOOKEXT HWND CreateTooltip(HWND hDlg, HWND hControl, const char* szText);
 HOOKEXT const char* HexPls(UINT uNumber, int width);
+#if !NOKUROKO
 HOOKEXT const char* FormatVersion(int iMajor, int iMinor, int iPatch);
+#endif
 HOOKEXT void ConsoleLog(int iLogLevel, const char* fmt, ...);
 HOOKEXT const char* GetLowHighScale(BYTE bScale);
 HOOKEXT BOOL FileExists(const char* name);
+#if !NOKUROKO
 HOOKEXT const char* GetModsFolderPath(void);
+#endif
 HOOKEXT const char* GetOnIdleStateEnumName(int iState);
 //HBITMAP CreateSpriteBitmap(int iSpriteID);
 HOOKEXT BOOL WritePrivateProfileIntA(const char *section, const char *name, int value, const char *ini_name);
@@ -290,14 +303,18 @@ DWORD WINAPI ConsoleThread(LPVOID lpParameter);
 BOOL ConsoleEvaluateCommand(const char* szCommandLine, BOOL bInteractive);
 BOOL ConsoleCmdClear(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdEcho(const char* szCommand, const char* szArguments);
+#if !NOKUROKO
 BOOL ConsoleCmdRun(const char* szCommand, const char* szArguments);
+#endif
 BOOL ConsoleCmdWait(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdHelp(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdShow(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdShowDebug(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdShowMemory(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdShowMicrosim(const char* szCommand, const char* szArguments);
+#if !NOKUROKO
 BOOL ConsoleCmdShowMods(const char* szCommand, const char* szArguments);
+#endif
 BOOL ConsoleCmdShowSound(const char* szCommand, const char* szArguments);
 //BOOL ConsoleCmdShowSprite(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdShowTile(const char* szCommand, const char* szArguments);
@@ -306,9 +323,11 @@ BOOL ConsoleCmdSet(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdSetDebug(const char* szCommand, const char* szArguments);
 BOOL ConsoleCmdSetTile(const char* szCommand, const char* szArguments);
 
+#if !NOKUROKO
 void LoadNativeCodeMods(void);
 
 DWORD WINAPI KurokoThread(LPVOID lpParameter);
+#endif
 
 extern const char *gamePrimaryKey;
 
@@ -333,9 +352,11 @@ extern BOOL bInSCURK;
 extern BOOL bConsoleEnabled;
 extern BOOL bSkipIntro;
 extern BOOL bUseAdvancedQuery;
+#if !NOKUROKO
 extern BOOL bKurokoVMInitialized;
 extern DWORD dwConsoleThreadID;
 extern DWORD dwKurokoThreadID;
+#endif
 
 extern BOOL bFontsInitialized;
 extern HFONT hFontMSSansSerifRegular8;
@@ -347,8 +368,10 @@ extern HFONT hFontArialBold10;
 extern HFONT hFontArialBold16;
 extern HFONT hSystemRegular12;
 
+#if !NOKUROKO
 extern std::map<HMODULE, sc2kfix_mod_info_t> mapLoadedNativeMods;
 extern std::map<HMODULE, std::vector<sc2kfix_mod_hook_t>> mapLoadedNativeModHooks;
+#endif
 extern std::map<DWORD, soundbufferinfo_t> mapSoundBuffers;
 extern std::vector<int> vectorRandomSongIDs;
 extern std::random_device rdRandomDevice;
@@ -361,7 +384,9 @@ extern BOOL bStatusDialogMoving;
 extern char szLatestRelease[24];
 extern BOOL bUpdateAvailable;
 
+#if !NOKUROKO
 HOOKEXT BOOL bHookStopProcessing;
+#endif
 
 // Hooks to inject in dllmain.cpp
 
@@ -402,7 +427,9 @@ extern UINT guzzardo_debug;
 extern UINT mci_debug;
 extern UINT military_debug;
 extern UINT mischook_debug;
+#if !NOKUROKO
 extern UINT modloader_debug;
+#endif
 extern UINT mus_debug;
 extern UINT registry_debug;
 extern UINT sc2x_debug;

--- a/modules/console.cpp
+++ b/modules/console.cpp
@@ -26,8 +26,10 @@
 #include <sc2kfix.h>
 #include "../resource.h"
 
+#if !NOKUROKO
 #include <kuroko/kuroko.h>
 #include <kuroko/util.h>
+#endif
 
 #ifdef CONSOLE_ENABLED
 BOOL bConsoleEnabled = TRUE;
@@ -36,7 +38,9 @@ BOOL bConsoleEnabled = FALSE;
 #endif
 
 HANDLE hConsoleThread;
+#if !NOKUROKO
 DWORD dwConsoleThreadID;
+#endif
 char szCmdBuf[256] = { 0 };
 BOOL bConsoleUndocumentedMode = FALSE;
 
@@ -48,7 +52,9 @@ console_command_t fpConsoleCommands[] = {
 	{ "echo", ConsoleCmdEcho, CONSOLE_COMMAND_DOCUMENTED, "Print to console" },
 	{ "echo!", ConsoleCmdEcho, CONSOLE_COMMAND_UNDOCUMENTED, "Print to console without newline" },
 	{ "help", ConsoleCmdHelp, CONSOLE_COMMAND_DOCUMENTED, "Display this help" },
+#if !NOKUROKO
 	{ "run", ConsoleCmdRun, CONSOLE_COMMAND_DOCUMENTED, "Run Kuroko code" },
+#endif
 	{ "set", ConsoleCmdSet, CONSOLE_COMMAND_DOCUMENTED, "Modify game and plugin behaviour" },
 	{ "show", ConsoleCmdShow, CONSOLE_COMMAND_DOCUMENTED, "Display various game and plugin information" },
 	{ "unset", ConsoleCmdSet, CONSOLE_COMMAND_DOCUMENTED, "Modify game and plugin behaviour" },
@@ -64,6 +70,7 @@ void ConsoleScriptSleep(DWORD dwMilliseconds) {
 
 // COMMAND: run ...
 
+#if !NOKUROKO
 BOOL ConsoleCmdRun(const char* szCommand, const char* szArguments) {
 	MSG msg;
 	std::string strPossibleScriptName;
@@ -108,6 +115,7 @@ BOOL ConsoleCmdRun(const char* szCommand, const char* szArguments) {
 	}
 	return TRUE;
 }
+#endif
 
 BOOL ConsoleCmdClear(const char* szCommand, const char* szArguments) {
 	WriteConsole(GetStdHandle(STD_OUTPUT_HANDLE), "\x1b[2J\x1b[0;0H", sizeof("\x1b[2J\x1b[0;0H"), NULL, NULL);
@@ -159,7 +167,9 @@ BOOL ConsoleCmdShow(const char* szCommand, const char* szArguments) {
 			"  show debug          Display enabled debugging options\n"
 			"  show memory ...     Display memory contents\n"
 			"  show microsim ...   Display microsim info\n"
+#if !NOKUROKO
 			"  show mods           Display loaded mods\n"
+#endif
 			"  show sound          Display sound info\n"
 			"  show tile ...       Display tile info\n"
 			"  show version        Display sc2kfix version info\n");
@@ -175,8 +185,10 @@ BOOL ConsoleCmdShow(const char* szCommand, const char* szArguments) {
 	if (!strcmp(szArguments, "microsim") || !strncmp(szArguments, "microsim ", 9))
 		return ConsoleCmdShowMicrosim(szCommand, szArguments);
 
+#if !NOKUROKO
 	if (!strcmp(szArguments, "mods") || !strncmp(szArguments, "mods ", 5))
 		return ConsoleCmdShowMods(szCommand, szArguments);
+#endif
 
 	if (!strcmp(szArguments, "sound") || !strncmp(szArguments, "sound ", 6))
 		return ConsoleCmdShowSound(szCommand, szArguments);
@@ -371,6 +383,7 @@ static const char* GetMidiDeviceTechnologyString(WORD wTechnology) {
 	}
 }
 
+#if !NOKUROKO
 BOOL ConsoleCmdShowMods(const char* szCommand, const char* szArguments) {
 	BOOL bDetail = FALSE;
 	if (*(szArguments + 4) == '\0' || *(szArguments + 5) == '\0')
@@ -409,6 +422,7 @@ BOOL ConsoleCmdShowMods(const char* szCommand, const char* szArguments) {
 	}
 	return TRUE;
 }
+#endif
 
 BOOL ConsoleCmdShowSound(const char* szCommand, const char* szArguments) {
 	if (dwDetectedVersion != SC2KVERSION_1996) {
@@ -541,15 +555,30 @@ BOOL ConsoleCmdShowVersion(const char* szCommand, const char* szArguments) {
 		szSC2KVersion = "1996 Special Edition";
 	}
 
+#if !NOKUROKO
 	KrkValue kuroko_version;
 	krk_tableGet_fast(&vm.system->fields, S("version"), &kuroko_version);
+#endif
 
+	// AF - the separation comma positioning in this case is deliberate
+	// in order to be a bit more "friendly" concerning missing or varied
+	// end-arguments depending on the build.
 	printf(
 		"sc2kfix version %s - https://sc2kfix.net\n"
 		"Plugin build info: %s\n"
 		"SimCity 2000 version: %s\n"
 		"Plugin loaded at 0x%08X\n"
-		"Kuroko version: Kuroko %s\n", szSC2KFixVersion, szSC2KFixBuildInfo, szSC2KVersion, (DWORD)hSC2KFixModule, AS_CSTRING(kuroko_version));
+#if !NOKUROKO
+		"Kuroko version: Kuroko %s\n" 
+#endif
+		,szSC2KFixVersion 
+		,szSC2KFixBuildInfo
+		,szSC2KVersion
+		,(DWORD)hSC2KFixModule 
+#if !NOKUROKO
+		,AS_CSTRING(kuroko_version)
+#endif
+	);
 
 	return TRUE;
 }

--- a/sc2kfix.sln
+++ b/sc2kfix.sln
@@ -25,12 +25,16 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Release|x86 = Release|x86
+		ReleaseNoKuroko|x86 = ReleaseNoKuroko|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{FB5DC66B-A2B0-4566-B243-453D58388A0D}.Release|x86.ActiveCfg = Release|Win32
 		{FB5DC66B-A2B0-4566-B243-453D58388A0D}.Release|x86.Build.0 = Release|Win32
+		{FB5DC66B-A2B0-4566-B243-453D58388A0D}.ReleaseNoKuroko|x86.ActiveCfg = Release|Win32
+		{FB5DC66B-A2B0-4566-B243-453D58388A0D}.ReleaseNoKuroko|x86.Build.0 = Release|Win32
 		{D12CCD5D-5BFD-4FF0-9D42-AEED8585E538}.Release|x86.ActiveCfg = Release|Win32
 		{D12CCD5D-5BFD-4FF0-9D42-AEED8585E538}.Release|x86.Build.0 = Release|Win32
+		{D12CCD5D-5BFD-4FF0-9D42-AEED8585E538}.ReleaseNoKuroko|x86.ActiveCfg = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sc2kfix.vcxproj
+++ b/sc2kfix.vcxproj
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="ReleaseNoKuroko|Win32">
+      <Configuration>ReleaseNoKuroko</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
@@ -21,6 +25,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -29,8 +40,14 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>winmm</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">
     <TargetName>winmm</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -61,6 +78,35 @@
       </AdditionalIncludeDirectories>
     </ResourceCompile>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;SC2KFIX_EXPORTS;NOKUROKO;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>"include";</AdditionalIncludeDirectories>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>hooks\exports.def</ModuleDefinitionFile>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
+      <AdditionalDependencies>"comctl32.lib";"shlwapi.lib";"winmm.lib";"wininet.lib";"dbghelp.lib";"wsock32.lib";"ws2_32.lib";%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NOKUROKO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="include\hooklists.h" />
     <ClInclude Include="include\json.hpp" />
@@ -72,14 +118,30 @@
     <ClInclude Include="include\winmm_exports.h" />
     <ClInclude Include="include\sc2k_1996.h" />
     <ClInclude Include="resource.h" />
-    <ClInclude Include="thirdparty\kuroko\dirent.h" />
-    <ClInclude Include="thirdparty\kuroko\methods.h" />
-    <ClInclude Include="thirdparty\kuroko\opcodes.h" />
-    <ClInclude Include="thirdparty\kuroko\opcode_enum.h" />
-    <ClInclude Include="thirdparty\kuroko\private.h" />
-    <ClInclude Include="thirdparty\kuroko\pthread.h" />
-    <ClInclude Include="thirdparty\kuroko\unistd.h" />
-    <ClInclude Include="thirdparty\kuroko\vendor\rline.h" />
+    <ClInclude Include="thirdparty\kuroko\dirent.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\methods.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\opcodes.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\opcode_enum.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\private.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\pthread.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\unistd.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="thirdparty\kuroko\vendor\rline.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="hooks\hook_animation.cpp" />
@@ -93,9 +155,13 @@
     <ClCompile Include="hooks\hook_querydialog.cpp" />
     <ClCompile Include="hooks\hook_sndPlaySound.cpp" />
     <ClCompile Include="hooks\hook_mmtimers.cpp" />
-    <ClCompile Include="modules\kuroko_glue.cpp" />
+    <ClCompile Include="modules\kuroko_glue.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="modules\military.cpp" />
-    <ClCompile Include="modules\mod_loader.cpp" />
+    <ClCompile Include="modules\mod_loader.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="modules\music.cpp" />
     <ClCompile Include="modules\registry_config.cpp" />
     <ClCompile Include="modules\sc2k_1996.cpp" />
@@ -106,57 +172,147 @@
     <ClCompile Include="modules\update_notifier.cpp" />
     <ClCompile Include="modules\smk.cpp" />
     <ClCompile Include="modules\scenario_status.cpp" />
-    <ClCompile Include="thirdparty\kuroko\builtins.c" />
-    <ClCompile Include="thirdparty\kuroko\chunk.c" />
-    <ClCompile Include="thirdparty\kuroko\compiler.c" />
-    <ClCompile Include="thirdparty\kuroko\debug.c" />
-    <ClCompile Include="thirdparty\kuroko\exceptions.c" />
-    <ClCompile Include="thirdparty\kuroko\kuroko.c" />
-    <ClCompile Include="thirdparty\kuroko\memory.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_dis.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_fileio.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_gc.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_locale.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_math.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_os.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_random.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_socket.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_stat.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_time.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_timeit.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module_wcwidth.c" />
-    <ClCompile Include="thirdparty\kuroko\modules\module__pheap.c" />
-    <ClCompile Include="thirdparty\kuroko\object.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_base.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_bytes.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_dict.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_function.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_gen.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_list.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_long.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_numeric.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_range.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_set.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_slice.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_str.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_tuple.c" />
-    <ClCompile Include="thirdparty\kuroko\obj_typing.c" />
-    <ClCompile Include="thirdparty\kuroko\parseargs.c" />
-    <ClCompile Include="thirdparty\kuroko\scanner.c" />
-    <ClCompile Include="thirdparty\kuroko\sys.c" />
-    <ClCompile Include="thirdparty\kuroko\table.c" />
-    <ClCompile Include="thirdparty\kuroko\threads.c" />
-    <ClCompile Include="thirdparty\kuroko\value.c" />
-    <ClCompile Include="thirdparty\kuroko\vendor\pthread.cpp" />
-    <ClCompile Include="thirdparty\kuroko\vendor\rline.c" />
-    <ClCompile Include="thirdparty\kuroko\vm.c" />
+    <ClCompile Include="thirdparty\kuroko\builtins.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\chunk.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\compiler.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\debug.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\exceptions.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\kuroko.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\memory.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_dis.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_fileio.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_gc.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_locale.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_math.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_os.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_random.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_socket.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_stat.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_time.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_timeit.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module_wcwidth.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\modules\module__pheap.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\object.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_base.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_bytes.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_dict.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_function.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_gen.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_list.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_long.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_numeric.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_range.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_set.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_slice.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_str.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_tuple.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\obj_typing.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\parseargs.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\scanner.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\sys.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\table.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\threads.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\value.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\vendor\pthread.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\vendor\rline.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="thirdparty\kuroko\vm.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="utility.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="hooks\exports.def" />
     <None Include="README.md" />
     <None Include="script.md" />
-    <None Include="thirdparty\kuroko\wcwidth._h" />
+    <None Include="thirdparty\kuroko\wcwidth._h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseNoKuroko|Win32'">true</ExcludedFromBuild>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="sc2kfix.rc" />

--- a/utility.cpp
+++ b/utility.cpp
@@ -85,6 +85,7 @@ HOOKEXT const char* HexPls(UINT uNumber, int width) {
 	return szRet;
 }
 
+#if !NOKUROKO
 HOOKEXT const char* FormatVersion(int iMajor, int iMinor, int iPatch) {
 	static char szRet[16] = { 0 };
 	if (!iPatch)
@@ -93,6 +94,7 @@ HOOKEXT const char* FormatVersion(int iMajor, int iMinor, int iPatch) {
 		sprintf_s(szRet, 16, "%d.%d%c", iMajor, iMinor, iPatch - 1 + 'a');
 	return szRet;
 }
+#endif
 
 extern FILE* fdLog;
 
@@ -174,12 +176,14 @@ HOOKEXT BOOL FileExists(const char* name) {
 	return FALSE;
 }
 
+#if !NOKUROKO
 HOOKEXT const char* GetModsFolderPath(void) {
 	static char szModsFolderPath[MAX_PATH];
 
 	sprintf_s(szModsFolderPath, MAX_PATH, "%s\\%s", szGamePath, SC2KFIX_MODSFOLDER);
 	return szModsFolderPath;
 }
+#endif
 
 HOOKEXT BOOL WritePrivateProfileIntA(const char *section, const char *name, int value, const char *ini_name) {
 	char szBuf[128 + 1];


### PR DESCRIPTION
Added 'ReleaseNoKuroko' build option, this should ease testing and building with and without Kuroko.

The 'ReleaseNoKuroko' option can be considered an equivalent of the r9_patches branch; if the library is build with this option it will be presumed as being R9.