### PR TITLE
Store the last city/tileset paths during load/save - main

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -278,7 +278,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		if (dwDetectedVersion == SC2KVERSION_DEMO)
 			gamePrimaryKey = "SimCity 2000 Win95 Demo";
 
-
 		// Registry check
 		int iInstallCheck;
 
@@ -287,6 +286,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 			ConsoleLog(LOG_INFO, "CORE: Portable entries created by faux-installer.");
 		else if (iInstallCheck == 1)
 			ConsoleLog(LOG_INFO, "CORE: Registry entries migrated by faux-installer.");
+
+		if (dwDetectedVersion == SC2KVERSION_1996) {
+			ConsoleLog(LOG_INFO, "CORE: Loading last stored load/save city and load tileset paths.");
+			LoadStoredPaths();
+		}
 
 		// Check for updates
 		if (bSettingsCheckForUpdates) {
@@ -424,6 +428,11 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID lpReserved) {
 		// Shut down the Kuroko thread
 		if (bKurokoVMInitialized)
 			PostThreadMessage(dwKurokoThreadID, WM_QUIT, NULL, NULL);
+
+		// Only save the stored paths during a graceful exit. (SC2K1996 only for now)
+		if (!bGameDead)
+			if (dwDetectedVersion == SC2KVERSION_1996)
+				SaveStoredPaths();
 
 		// Send a closing message and close the log file
 		ReleaseSMKFuncs();

--- a/include/sc2kfix.h
+++ b/include/sc2kfix.h
@@ -252,6 +252,7 @@ extern int iForcedBits;
 
 // Path adjustment (from registry_pathing area)
 
+BOOL L_IsPathValid(const char *pStr);
 const char *AdjustSource(char *buf, const char *path);
 
 // Utility functions
@@ -283,6 +284,8 @@ HOOKEXT_CPP void DecodeDWORDArray(DWORD* dwArray, json::JSON jsonArray, size_t i
 LONG WINAPI CrashHandler(LPEXCEPTION_POINTERS lpExceptions);
 BOOL CALLBACK InstallDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
 BOOL CALLBACK SettingsDialogProc(HWND hwndDlg, UINT message, WPARAM wParam, LPARAM lParam);
+void LoadStoredPaths();
+void SaveStoredPaths();
 int DoRegistryCheckAndInstall(void);
 void SetGamePath(void);
 const char *GetIniPath();
@@ -323,6 +326,9 @@ void LoadNativeCodeMods(void);
 DWORD WINAPI KurokoThread(LPVOID lpParameter);
 
 extern const char *gamePrimaryKey;
+
+extern char szLastStoredCityPath[MAX_PATH + 1];
+extern char szLastStoredTileSetPath[MAX_PATH + 1];
 
 extern BOOL bGameDead;
 extern HMODULE hRealWinMM;


### PR DESCRIPTION
The paths are saved in the sc2kfix.ini and re-used during subsequent load/save calls.

The stored paths:
 - CityPath
 - TileSetPath

The CityPath that's stored is used for both load and save city calls at this point.